### PR TITLE
Make LongString a newtype for ByteString. Fix encoding for some FieldValues

### DIFF
--- a/Network/AMQP.hs
+++ b/Network/AMQP.hs
@@ -705,7 +705,7 @@ openConnection' host port vhost loginName loginPassword = withSocketsDo $ do
     start_ok = (Frame 0 (MethodPayload (Connection_start_ok (FieldTable M.empty)
         (ShortString "AMQPLAIN")
         --login has to be a table without first 4 bytes
-        (LongString $ T.pack $ drop 4 $ BL.unpack $ runPut $ put $ FieldTable $ M.fromList [("LOGIN",FVString loginName), ("PASSWORD", FVString loginPassword)])
+        (LongString $ runPut $ put $ FieldTable $ M.fromList [("LOGIN",FVShortString loginName), ("PASSWORD", FVShortString loginPassword)])
         (ShortString "en_US")) ))
     open = (Frame 0 (MethodPayload (Connection_open
         (ShortString vhost)  --virtual host


### PR DESCRIPTION
As part of #18, it came up that `LongString` really should be a `newtype` wrapper for `ByteString` and not `Text`.
This commit facilitates this.

Additionally, I added a distinction between `FieldValue`s for `ShortString` and `LongString`. The data constructor `FVString` is now gone, but if you want to keep it for the sake of backwards compatibility, I can rename `FVLongString` back to `FVString`.

I also fixed the encoding of some `FieldValue`s. According to [4.2.1 Formal Protocol Grammar](http://www.rabbitmq.com/resources/specs/amqp0-9-1.pdf) in the AMQP Protocol Specification, `short-int` and `long-long-int` are encoded as follows:

```
'U' short-int
'L' long-long-int
```

Whereas the currently (prior to this PR) used `'s'` and `'l'` are used for `short-string` and `long-long-uint` respectively.

Regards,
  Gerolf

Update: I decided to put the `LongString` change into this PR as well.
