### PR TITLE
Make LongString a newtype for BS.ByteString.

### DIFF
--- a/Network/AMQP.hs
+++ b/Network/AMQP.hs
@@ -705,7 +705,7 @@ openConnection' host port vhost loginName loginPassword = withSocketsDo $ do
     start_ok = (Frame 0 (MethodPayload (Connection_start_ok (FieldTable M.empty)
         (ShortString "AMQPLAIN")
         --login has to be a table without first 4 bytes
-        (LongString $ T.pack $ drop 4 $ BL.unpack $ runPut $ put $ FieldTable $ M.fromList [("LOGIN",FVString loginName), ("PASSWORD", FVString loginPassword)])
+        (LongString $ BL.toStrict $ BL.drop 4 $ runPut $ put $ FieldTable $ M.fromList [("LOGIN",FVString loginName), ("PASSWORD", FVString loginPassword)])
         (ShortString "en_US")) ))
     open = (Frame 0 (MethodPayload (Connection_open
         (ShortString vhost)  --virtual host


### PR DESCRIPTION
As part of #18, it came up that `LongString` could/should become a `newtype` wrapper for `ByteString`. 
I wasn't sure whether it should wrap the strict or lazy incarnation of `ByteString`. I read up on the differences and ultimately went with the strict one, as the few actual usages of `LongString` probably won't be used for extremely large binary data anyway (might be wild speculation on my part). Using the strict `ByteString` also necessitated adding a call to `toStrict` in [AMQP.hs](https://github.com/gseitz/amqp/compare/LongString-as-ByteString?expand=1#L0R708).

Please let me know if I'm off one any of the aforementioned points or you want anything changed.

Regards,
  Gerolf

P.S.: If and when you're happy with this change, I will rebase #18 on these changes for the type of the SASL challenge responses.
