### PR TITLE
Capture connection parameters as ConnectionOpts.

### DIFF
--- a/Network/AMQP/Helpers.hs
+++ b/Network/AMQP/Helpers.hs
@@ -33,3 +33,7 @@ killLock :: Lock -> IO Bool
 killLock (Lock a b) = do
     modifyMVar_ a $ const (return True)
     tryPutMVar b ()
+
+chooseMin :: Ord a => a -> Maybe a -> a
+chooseMin a (Just b) = min a b
+chooseMin a Nothing  = a


### PR DESCRIPTION
Various connection related parameters are now captured in `ConnectionOpts` as discussed in #17, with the following addition:

The host/port field is of type `[(String, PortNumber)]`, which allows to specify several hosts in a cluster of brokers. The first successful connection will be used.

Given this list of hosts

``` haskell
defaultConnectionParams {
  cpCluster = [("127.0.0.1", 1742), ("localhost", 1337), ("localhost", 5672)]
}
```

Successful connection (the last connection details were valid and a consumer was started):

```
*Example> main
Error connecting to ("127.0.0.1",1742): connect: does not exist (Connection refused)
Error connecting to ("localhost",1337): connect: does not exist (Connection refused)

connection closed
```

Failed connection without the broker running:

```
Error connecting to ("127.0.0.1",1742): connect: does not exist (Connection refused)
Error connecting to ("localhost",1337): connect: does not exist (Connection refused)
Error connecting to ("localhost",5672): connect: does not exist (Connection refused)
*** Exception: ConnectionClosedException "Could not connect to any of the provided brokers: [(\"127.0.0.1\",1742),(\"localhost\",1337),(\"localhost\",5672)]"
```
