### PR TITLE
Exception handling

### DIFF
--- a/Network/AMQP/Generated.hs
+++ b/Network/AMQP/Generated.hs
@@ -15,8 +15,7 @@ getContentHeaderProperties 50 = getPropBits 0 >>= \[] ->  return CHQueue
 getContentHeaderProperties 60 = getPropBits 14 >>= \[a,b,c,d,e,f,g,h,i,j,k,l,m,n] -> condGet a >>= \a' -> condGet b >>= \b' -> condGet c >>= \c' -> condGet d >>= \d' -> condGet e >>= \e' -> condGet f >>= \f' -> condGet g >>= \g' -> condGet h >>= \h' -> condGet i >>= \i' -> condGet j >>= \j' -> condGet k >>= \k' -> condGet l >>= \l' -> condGet m >>= \m' -> condGet n >>= \n' ->  return (CHBasic a' b' c' d' e' f' g' h' i' j' k' l' m' n' )
 getContentHeaderProperties 90 = getPropBits 0 >>= \[] ->  return CHTx
 getContentHeaderProperties 85 = getPropBits 0 >>= \[] ->  return CHConfirm
-
-getContentHeaderProperties n = error ("Unexpected content header properties: " ++ show n)
+getContentHeaderProperties x = error ("getContentHeaderProperties: Unexpected content header properties " ++ show x)
 putContentHeaderProperties :: ContentHeaderProperties -> Put
 putContentHeaderProperties CHConnection = putPropBits []
 putContentHeaderProperties CHChannel = putPropBits []
@@ -224,7 +223,7 @@ instance Binary MethodPayload where
 			(90,31) ->  return Tx_rollback_ok
 			(85,10) -> get >>= \a ->  return (Confirm_select a)
 			(85,11) ->  return Confirm_select_ok
-			x -> error ("Unexpected classID and methodID: " ++ show x)
+			x -> error ("get: Unexpected classID and methodID " ++ show x)
 data MethodPayload =
 
 	Connection_start

--- a/Network/AMQP/Internal.hs
+++ b/Network/AMQP/Internal.hs
@@ -95,8 +95,7 @@ readAssembly chan = do
                     --several frames containing the content will follow, so read them
                     (props, msg) <- collectContent chan
                     return $ ContentMethod p props msg
-                else do
-                    return $ SimpleMethod p
+                else return $ SimpleMethod p
         x -> error $ "didn't expect frame: " ++ show x
 
 -- | reads a contentheader and contentbodies and assembles them
@@ -518,8 +517,7 @@ writeFrames chan payloads =
                         ( \(_ :: CE.IOException) -> do
                             CE.throwIO $ userError "connection not open"
                         )
-                else do
-                    CE.throwIO $ userError "channel not open"
+                else CE.throwIO $ userError "channel not open"
 
 writeAssembly' :: Channel -> Assembly -> IO ()
 writeAssembly' chan (ContentMethod m properties msg) = do

--- a/Network/AMQP/Internal.hs
+++ b/Network/AMQP/Internal.hs
@@ -256,7 +256,7 @@ openConnection'' connOpts = withSocketsDo $ do
             (\(ex :: CE.SomeException) -> do
                 putStrLn $ "Error connecting to " ++ show (host, port) ++ ": " ++ show ex
                 connect rest)
-            (return)
+            return
             result
     connect [] = CE.throwIO $ ConnectionClosedException $ "Could not connect to any of the provided brokers: " ++ show (coServers connOpts)
     selectSASLMechanism handle serverMechanisms =
@@ -447,7 +447,7 @@ channelReceiver chan = do
                 312 -> Unroutable errText
                 313 -> NoConsumers errText
                 404 -> NotFound errText
-                num -> error $ "unexpected return error code: " ++ (show num)
+                num -> error $ "unexpected return error code: " ++ show num
             pubError = PublishError replyError (Just exchange) routingKey
         in pubError
     basicReturnToPublishError x = error ("basicReturnToPublishError fail: " ++ show x)

--- a/Network/AMQP/Internal.hs
+++ b/Network/AMQP/Internal.hs
@@ -329,7 +329,7 @@ addConnectionClosedHandler conn ifClosed handler = do
             Just _ | ifClosed == True -> handler
 
             -- otherwise add it to the list
-            _ -> modifyMVar_ (connClosedHandlers conn) $ \old -> return $ handler:old
+            _ -> modifyMVar_ (connClosedHandlers conn) $ return . (handler:)
 
 readFrame :: Handle -> IO Frame
 readFrame handle = do
@@ -459,7 +459,7 @@ addReturnListener chan listener = do
 -- closes the channel internally; but doesn't tell the server
 closeChannel' :: Channel -> Text -> IO ()
 closeChannel' c reason = do
-    modifyMVar_ (connChannels $ connection c) $ \old -> return $ IM.delete (fromIntegral $ channelID c) old
+    modifyMVar_ (connChannels $ connection c) $ return . IM.delete (fromIntegral $ channelID c)
     -- mark channel as closed
     modifyMVar_ (chanClosed c) $ \x -> do
         if isNothing x

--- a/Network/AMQP/Internal.hs
+++ b/Network/AMQP/Internal.hs
@@ -326,7 +326,7 @@ addConnectionClosedHandler conn ifClosed handler = do
     withMVar (connClosed conn) $ \cc ->
         case cc of
             -- connection is already closed, so call the handler directly
-            Just _ | ifClosed == True -> handler
+            Just _ | ifClosed -> handler
 
             -- otherwise add it to the list
             _ -> modifyMVar_ (connClosedHandlers conn) $ return . (handler:)

--- a/Network/AMQP/Internal.hs
+++ b/Network/AMQP/Internal.hs
@@ -254,7 +254,7 @@ openConnection'' connOpts = withSocketsDo $ do
         result <- CE.try (connectTo host $ PortNumber port)
         either
             (\(ex :: CE.SomeException) -> do
-                putStrLn $ "Error connecting to "++show (host, port)++": "++show ex
+                putStrLn $ "Error connecting to " ++ show (host, port) ++ ": " ++ show ex
                 connect rest)
             (return)
             result
@@ -264,8 +264,8 @@ openConnection'' connOpts = withSocketsDo $ do
             clientMechanisms = coAuth connOpts
             clientSaslList = map saslName clientMechanisms
             maybeSasl = F.find (\(SASLMechanism name _ _) -> elem name serverSaslList) clientMechanisms
-        in abortIfNothing maybeSasl handle
-            ("None of the provided SASL mechanisms "++show clientSaslList++" is supported by the server "++show serverSaslList++".")
+        in abortIfNothing maybeSasl handle $
+             "None of the provided SASL mechanisms " ++ show clientSaslList ++ " is supported by the server " ++ show serverSaslList ++ "."
 
     start_ok sasl = (Frame 0 (MethodPayload (Connection_start_ok (FieldTable M.empty)
         (ShortString $ saslName sasl)
@@ -277,13 +277,13 @@ openConnection'' connOpts = withSocketsDo $ do
         case tuneOrSecure of
             Frame 0 (MethodPayload (Connection_secure (LongString challenge))) -> do
                 processChallenge <- abortIfNothing (saslChallengeFunc sasl)
-                    handle $ "The server provided a challenge, but the selected SASL mechanism "++show (saslName sasl)++" is not equipped with a challenge processing function."
+                    handle $ "The server provided a challenge, but the selected SASL mechanism " ++ show (saslName sasl) ++ " is not equipped with a challenge processing function."
                 challengeResponse <- processChallenge challenge
                 writeFrame handle (Frame 0 (MethodPayload (Connection_secure_ok (LongString challengeResponse))))
                 handleSecureUntilTune handle sasl
 
             tune@(Frame 0 (MethodPayload (Connection_tune _ _ _))) -> return tune
-            x -> error $ "handleSecureUntilTune fail. received message: "++show x
+            x -> error ("handleSecureUntilTune fail. received message: " ++ show x)
 
     open = (Frame 0 (MethodPayload (Connection_open
         (ShortString $ coVHost connOpts)
@@ -439,7 +439,7 @@ channelReceiver chan = do
             pubError = basicReturnToPublishError basicReturn
         withMVar (returnListeners chan) $ \listeners ->
             forM_ listeners $ \l -> CE.catch (l (msg, pubError)) $ \(ex :: CE.SomeException) ->
-                putStrLn $ "return listener on channel ["++(show $ channelID chan)++"] handling error ["++show pubError++"] threw exception: "++show ex
+                putStrLn $ "return listener on channel [" ++ show (channelID chan) ++ "] handling error [" ++ show pubError ++ "] threw exception: " ++ show ex
     handleAsync m = error ("Unknown method: " ++ show m)
 
     basicReturnToPublishError (Basic_return code (ShortString errText) (ShortString exchange) (ShortString routingKey)) =
@@ -450,7 +450,7 @@ channelReceiver chan = do
                 num -> error $ "unexpected return error code: " ++ (show num)
             pubError = PublishError replyError (Just exchange) routingKey
         in pubError
-    basicReturnToPublishError x = error $ "basicReturnToPublishError fail: "++show x
+    basicReturnToPublishError x = error ("basicReturnToPublishError fail: " ++ show x)
 
 -- | registers a callback function that is called whenever a message is returned from the broker ('basic.return').
 addReturnListener :: Channel -> ((Message, PublishError) -> IO ()) -> IO ()

--- a/Network/AMQP/Internal.hs
+++ b/Network/AMQP/Internal.hs
@@ -76,6 +76,7 @@ data PublishError = PublishError
 data ReturnReplyCode = Unroutable Text
                      | NoConsumers Text
                      | NotFound Text
+                     | Unknown ShortInt Text
     deriving (Eq, Read, Show)
 
 ------------- ASSEMBLY -------------------------
@@ -446,7 +447,7 @@ channelReceiver chan = do
                 312 -> Unroutable errText
                 313 -> NoConsumers errText
                 404 -> NotFound errText
-                num -> error $ "unexpected return error code: " ++ show num
+                num -> Unknown num errText
             pubError = PublishError replyError (Just exchange) routingKey
         in pubError
     basicReturnToPublishError x = error ("basicReturnToPublishError fail: " ++ show x)

--- a/Network/AMQP/Internal.hs
+++ b/Network/AMQP/Internal.hs
@@ -176,13 +176,13 @@ connectionReceiver conn = do
         writeFrame (connHandle conn) $ Frame 0 $ MethodPayload Connection_close_ok
         modifyMVar_ (connClosed conn) $ const $ return $ Just $ T.unpack errorMsg
         killThread =<< myThreadId
-    forwardToChannel 0 payload = putStrLn ("forwardToChannel: Unexpected msg on channel zero: " ++ show payload)
+    forwardToChannel 0 payload = error ("forwardToChannel: Unexpected msg on channel zero: " ++ show payload)
     forwardToChannel chanID payload = do
         --got asynchronous msg => forward to registered channel
         withMVar (connChannels conn) $ \cs -> do
             case IM.lookup (fromIntegral chanID) cs of
                 Just c -> writeChan (inQueue $ fst c) payload
-                Nothing -> putStrLn ("forwardToChannel: Channel not open " ++ show chanID)
+                Nothing -> error ("forwardToChannel: Channel not open " ++ show chanID)
 
 -- | Opens a connection to a broker specified by the given 'ConnectionOpts' parameter.
 openConnection'' :: ConnectionOpts -> IO Connection

--- a/Network/AMQP/Internal.hs
+++ b/Network/AMQP/Internal.hs
@@ -246,7 +246,7 @@ openConnection'' connOpts = withSocketsDo $ do
                 -- mark connection as closed, so all pending calls to 'closeConnection' can now return
                 void $ tryPutMVar ccl ()
 
-                -- notify connection-close-handlers
+                -- notify connection-closed-handlers
                 withMVar cClosedHandlers sequence
     return conn
   where

--- a/Network/AMQP/Protocol.hs
+++ b/Network/AMQP/Protocol.hs
@@ -70,7 +70,7 @@ getPayload 2 _ = do --content header frame
 getPayload 3 payloadSize = do --content body frame
     payload <- getLazyByteString $ fromIntegral payloadSize
     return (ContentBodyPayload payload)
-getPayload n _ = error ("Unknown frame payload: " ++ show n)
+getPayload x _ = error ("getPayload: Unexpected frame payload " ++ show x)
 
 putPayload :: FramePayload -> Put
 putPayload (MethodPayload payload) = put payload

--- a/Network/AMQP/Types.hs
+++ b/Network/AMQP/Types.hs
@@ -38,7 +38,7 @@ readMany :: (Show a, Binary a) => BL.ByteString -> [a]
 readMany = runGet (readMany' [] 0)
 
 readMany' :: (Show a, Binary a) => [a] -> Int -> Get [a]
-readMany' _ 1000 = error "readMany overflow"
+readMany' _ 1000 = error "readMany': overflow"
 readMany' acc overflow = do
     x <- get
     emp <- isEmpty
@@ -71,7 +71,7 @@ instance Binary ShortString where
     put (ShortString x) = do
         let s = T.encodeUtf8 x
         if BS.length s > 255
-            then error "cannot encode ShortString with length > 255"
+            then error "put: Cannot encode ShortString with length > 255"
             else do
                 putWord8 $ fromIntegral (BS.length s)
                 putByteString s
@@ -157,7 +157,7 @@ instance Binary FieldValue where
             'x' -> do
                 len <- get :: Get Word32
                 FVByteArray <$> getByteString (fromIntegral len)
-            c   -> error ("Unknown field type: " ++ show c)
+            x   -> error ("get: Unknown field type " ++ show x)
 
     put (FVBool x) = put 't' >> put x
     put (FVInt8 x) = put 'b' >> put x

--- a/Tools/Builder.hs
+++ b/Tools/Builder.hs
@@ -60,8 +60,8 @@ main = do
         "import Network.AMQP.Types\n\n" ++
 
         "getContentHeaderProperties :: ShortInt -> Get ContentHeaderProperties" ++ "\n" ++
-        contentHeadersGetInst ++ "\n" ++
-        "getContentHeaderProperties n = error (\"Unexpected content header properties: \" ++ show n)" ++ "\n" ++
+        contentHeadersGetInst ++
+        "getContentHeaderProperties x = error (\"getContentHeaderProperties: Unexpected content header properties \" ++ show x)" ++ "\n" ++
 
         "putContentHeaderProperties :: ContentHeaderProperties -> Put" ++ "\n" ++
         contentHeadersPutInst ++ "\n" ++
@@ -126,7 +126,7 @@ main = do
         "\t\tmethodID <- getWord16be\n" ++
         "\t\tcase (classID, methodID) of\n" ++
         binaryGetInst ++
-        "\t\t\tx -> error (\"Unexpected classID and methodID: \" ++ show x)" ++ "\n" ++
+        "\t\t\tx -> error (\"get: Unexpected classID and methodID \" ++ show x)" ++ "\n" ++
 
         -- data declaration
         dataDecl)
@@ -141,7 +141,7 @@ translateType "bit" = "Bit"
 translateType "table" = "FieldTable"
 translateType "longlong" = "LongLongInt"
 translateType "timestamp" = "Timestamp"
-translateType x = error x
+translateType x = error ("translateType: unexpected type " ++ show x)
 
 fixClassName :: String -> String
 fixClassName s = (toUpper $ head s) : (tail s)
@@ -368,4 +368,4 @@ readField f =
         case (fType, fDomain) of
             (Just t, _) -> TypeField fieldName t
             (_, Just d) -> DomainField fieldName d
-            _           -> error ("Missing field type and domain attributes")
+            _           -> error ("readField: Missing field type and domain attributes")

--- a/amqp.cabal
+++ b/amqp.cabal
@@ -18,7 +18,7 @@ Extra-source-files:  examples/ExampleConsumer.hs,
                      examples/ExampleProducer.hs
 
 Library
-  Build-Depends:      base >= 4 && < 5, binary >= 0.7, containers>=0.2, bytestring>=0.9, network>=2.2.3.1, data-binary-ieee754>=0.4.2.1, text>=0.11.2
+  Build-Depends:      base >= 4 && < 5, binary >= 0.7, containers>=0.2, bytestring>=0.10, network>=2.2.3.1, data-binary-ieee754>=0.4.2.1, text>=0.11.2
   Exposed-modules:    Network.AMQP, Network.AMQP.Types
   Other-modules:      Network.AMQP.Generated, Network.AMQP.Helpers, Network.AMQP.Protocol, Network.AMQP.Internal
   GHC-Options:        -Wall


### PR DESCRIPTION
I've made some improvements to the exception handling of the library:
1. Unexpected situations should not write an error to stdout, instead, throw a custom exception or fail using `error` when it's really not supposed to happen. This allows users of the library to deal with such situations, instead of just seeing some message in their logs.
2. Exceptions should not be caught and just written to stdout, for the same reasons as above.
3. The handler that runs when a connection is closed could not distinguish between closings due to user request or an exception. I've made a simple change that records any exception and provides this to the handler so users of the library can distinguish the two cases. Note that this does change the interface of `addConnectionClosedHandler`. If desired, a wrapper function can be added to preserve the old interface. But, in general one wants to know why a connection was closed, so changing the interface is justifiable to me.
