### PR TITLE
Added fromURI to parse amqp URIs

### DIFF
--- a/Network/AMQP.hs
+++ b/Network/AMQP.hs
@@ -126,6 +126,7 @@ module Network.AMQP (
 ) where
 
 import Control.Concurrent
+import Data.List.Split (splitOn)
 import Data.Binary
 import Data.Binary.Put
 import Network


### PR DESCRIPTION
Parsing amqp URIs allows for fewer strings in config files and less parameters to pass around. The returned connectionOpts can either be passed directly to openConnection'' or modified further. The method fromURI is implemented without adding any dependencies (such as regexp) to the project.
