### PR TITLE
Add heartbeat support.

### DIFF
--- a/Network/AMQP.hs
+++ b/Network/AMQP.hs
@@ -120,7 +120,7 @@ module Network.AMQP (
 
     -- * Exceptions
     AMQPException(..),
-    
+
     -- * URI parsing
     fromURI
 ) where
@@ -506,7 +506,7 @@ flow chan active = do
 --
 --     * max frame size: @131072@
 --
---     * no heartbeat expected from the server
+--     * use the heartbeat delay suggested by the broker
 --
 --     * no limit on the number of used channels
 --
@@ -567,7 +567,7 @@ qos chan prefetchSize prefetchCount = do
         False
         ))
     return ()
-    
+
 -- | Parses amqp standard URI of the form @amqp://user:password@host:port/vhost@ and returns a @ConnectionOpts@ for use with @openConnection''@
 -- | Any of these fields may be empty and will be replaced with defaults from @amqp://guest:guest@localhost:5672/@
 fromURI :: String -> ConnectionOpts

--- a/Network/AMQP/Helpers.hs
+++ b/Network/AMQP/Helpers.hs
@@ -1,7 +1,9 @@
+{-# LANGUAGE ScopedTypeVariables #-}
 module Network.AMQP.Helpers where
 
-import Control.Concurrent.MVar
+import Control.Concurrent
 import Control.Monad
+import System.Clock
 
 import qualified Data.ByteString.Char8 as BS
 import qualified Data.ByteString.Lazy.Char8 as BL
@@ -37,3 +39,13 @@ killLock (Lock a b) = do
 chooseMin :: Ord a => a -> Maybe a -> a
 chooseMin a (Just b) = min a b
 chooseMin a Nothing  = a
+
+getTimestamp :: IO Int
+getTimestamp = fmap µs $ getTime Monotonic
+  where
+  	µs spec = (sec spec) * 1000 * 1000 + (nsec spec) `div` 1000
+
+scheduleAtFixedRate :: Int -> IO () -> IO ThreadId
+scheduleAtFixedRate interval_µs action = forkIO $ forever $ do
+    action
+    threadDelay interval_µs

--- a/amqp.cabal
+++ b/amqp.cabal
@@ -18,7 +18,7 @@ Extra-source-files:  examples/ExampleConsumer.hs,
                      examples/ExampleProducer.hs
 
 Library
-  Build-Depends:      base >= 4 && < 5, binary >= 0.7, containers>=0.2, bytestring>=0.9, network>=2.2.3.1, data-binary-ieee754>=0.4.2.1, text>=0.11.2, split>=0.2
+  Build-Depends:      base >= 4 && < 5, binary >= 0.7, containers>=0.2, bytestring>=0.9, network>=2.2.3.1, data-binary-ieee754>=0.4.2.1, text>=0.11.2, split>=0.2, clock == 0.3
   Exposed-modules:    Network.AMQP, Network.AMQP.Types
   Other-modules:      Network.AMQP.Generated, Network.AMQP.Helpers, Network.AMQP.Protocol, Network.AMQP.Internal
   GHC-Options:        -Wall


### PR DESCRIPTION
Hi,
This PR adds heartbeat support, as already discussed in #25.
- If no heartbeat delay (`coHeartbeatDelay`) is specified, the server provided value is used. Disabling heartbeating can be achieved by setting `coHeartbeatDelay` to `Just 0`.
- In case heartbeating is enabled, both incoming and outgoing heartbeats are checked every `timeout / 4` seconds.
  - If the last outgoing frame was sent longer than `now - timeout / 2` ago, send a heartbeat frame to avoid running into a timeout on the server.
  - If the last incoming frame was received longer than `timeout * 2` ago, kill the connection abruptly without sending the `close` frame.
- A dedicated thread (`forkIO`) is used to schedule the hearbeat checks.
- Each check is then executed in its own dedicated thread (`forkIO`) to not skew the rate at which the checks need to be executed. (*)

(*) Does this make sense at all? Should any exception during the heartbeat check be caught and "logged" (as opposed to just letting the thread die)?

@fegu: Could you give this a spin? I did some local tests, but as you have experienced problems in the past with some network hardware, I'd be interested in your experience report.

Please let me know if something is missing or you need anything changed.

Cheers
