### PR TITLE
Use Int64 to avoid potential integer overflow .

### DIFF
--- a/Network/AMQP/Helpers.hs
+++ b/Network/AMQP/Helpers.hs
@@ -3,6 +3,7 @@ module Network.AMQP.Helpers where
 
 import Control.Concurrent
 import Control.Monad
+import Data.Int (Int64)
 import System.Clock
 
 import qualified Data.ByteString.Char8 as BS
@@ -40,10 +41,12 @@ chooseMin :: Ord a => a -> Maybe a -> a
 chooseMin a (Just b) = min a b
 chooseMin a Nothing  = a
 
-getTimestamp :: IO Int
+getTimestamp :: IO Int64
 getTimestamp = fmap µs $ getTime Monotonic
   where
-  	µs spec = (sec spec) * 1000 * 1000 + (nsec spec) `div` 1000
+  	seconds spec = (fromIntegral . sec) spec * 1000 * 1000
+  	micros spec = (fromIntegral . nsec) spec `div` 1000
+  	µs spec = (seconds spec) + (micros spec)
 
 scheduleAtFixedRate :: Int -> IO () -> IO ThreadId
 scheduleAtFixedRate interval_µs action = forkIO $ forever $ do


### PR DESCRIPTION
As discussed in #30, the timestamp is now captured as `Int64`, which should avoid running into integer overflow scenarios with heartbeats.
