### PR TITLE
Add support for TLS connections (FIX #39)

### DIFF
--- a/Network/AMQP.hs
+++ b/Network/AMQP.hs
@@ -49,6 +49,7 @@ module Network.AMQP (
     -- * Connection
     Connection,
     ConnectionOpts(..),
+    TLSSettings(..),
     defaultConnectionOpts,
     openConnection,
     openConnection',
@@ -519,7 +520,7 @@ flow chan active = do
 --     * no limit on the number of used channels
 --
 defaultConnectionOpts :: ConnectionOpts
-defaultConnectionOpts = ConnectionOpts [("localhost", 5672)] "/" [plain "guest" "guest"] (Just 131072) Nothing Nothing
+defaultConnectionOpts = ConnectionOpts [("localhost", 5672)] "/" [plain "guest" "guest"] (Just 131072) Nothing Nothing Nothing
 
 -- | @openConnection hostname virtualHost loginName loginPassword@ opens a connection to an AMQP server running on @hostname@.
 -- @virtualHost@ is used as a namespace for AMQP resources (default is \"/\"), so different applications could use multiple virtual hosts on the same AMQP server.

--- a/amqp.cabal
+++ b/amqp.cabal
@@ -18,7 +18,7 @@ Extra-source-files:  examples/ExampleConsumer.hs,
                      examples/ExampleProducer.hs
 
 Library
-  Build-Depends:      base >= 4 && < 5, binary >= 0.7, containers>=0.2, bytestring>=0.9, network>=2.2.3.1, data-binary-ieee754>=0.4.2.1, text>=0.11.2, split>=0.2, clock >= 0.4.0.1, monad-control >= 0.3
+  Build-Depends:      base >= 4 && < 5, binary >= 0.7, containers>=0.2, bytestring>=0.9, network>=2.2.3.1, data-binary-ieee754>=0.4.2.1, text>=0.11.2, split>=0.2, clock >= 0.4.0.1, monad-control >= 0.3, connection == 0.2.*
   Exposed-modules:    Network.AMQP, Network.AMQP.Types, Network.AMQP.Lifted
   Other-modules:      Network.AMQP.Generated, Network.AMQP.Helpers, Network.AMQP.Protocol, Network.AMQP.Internal
   GHC-Options:        -Wall
@@ -46,3 +46,4 @@ test-suite spec
       base >= 4 && < 5, binary >= 0.7, containers>=0.2, bytestring>=0.9, network>=2.2.3.1, data-binary-ieee754>=0.4.2.1, text>=0.11.2, split>=0.2, clock >= 0.4.0.1
     , hspec              >= 1.3
     , hspec-expectations >= 0.3.3
+    , connection == 0.2.*

--- a/examples/ExampleTLSConsumer.hs
+++ b/examples/ExampleTLSConsumer.hs
@@ -1,0 +1,46 @@
+{-# OPTIONS -XOverloadedStrings #-}
+import Network.AMQP
+
+import qualified Data.ByteString.Lazy.Char8 as BL
+
+
+main = do
+    let opts = defaultConnectionOpts {
+            coServers = [("127.0.0.1", 5671)]
+          , coTLSSettings = Just TLSTrusted
+          }
+    conn <- openConnection'' opts
+    chan <- openChannel conn
+
+
+    --declare queues, exchanges and bindings
+    declareQueue chan newQueue {queueName = "myQueueDE"}
+    declareQueue chan newQueue {queueName = "myQueueEN"}
+
+    declareExchange chan newExchange {exchangeName = "topicExchg", exchangeType = "topic"}
+    bindQueue chan "myQueueDE" "topicExchg" "de.*"
+    bindQueue chan "myQueueEN" "topicExchg" "en.*"
+
+
+    --subscribe to the queues
+    consumeMsgs chan "myQueueDE" Ack myCallbackDE
+    consumeMsgs chan "myQueueEN" Ack myCallbackEN
+
+
+    getLine -- wait for keypress
+    closeConnection conn
+    putStrLn "connection closed"
+
+
+
+
+myCallbackDE :: (Message,Envelope) -> IO ()
+myCallbackDE (msg, env) = do
+    putStrLn $ "received from DE: "++(BL.unpack $ msgBody msg)
+    ackEnv env
+
+
+myCallbackEN :: (Message,Envelope) -> IO ()
+myCallbackEN (msg, env) = do
+    putStrLn $ "received from EN: "++(BL.unpack $ msgBody msg)
+    ackEnv env

--- a/examples/ExampleTLSProducer.hs
+++ b/examples/ExampleTLSProducer.hs
@@ -1,0 +1,35 @@
+{-# OPTIONS -XOverloadedStrings #-}
+import Network.AMQP
+
+import qualified Data.ByteString.Lazy.Char8 as BL
+
+
+main = do
+    let opts = defaultConnectionOpts {
+            coServers = [("127.0.0.1", 5671)]
+          , coTLSSettings = Just TLSTrusted
+          }
+    conn <- openConnection'' opts
+    chan <- openChannel conn
+
+
+    --declare queues, exchanges and bindings
+    declareQueue chan newQueue {queueName = "myQueueDE"}
+    declareQueue chan newQueue {queueName = "myQueueEN"}
+
+    declareExchange chan newExchange {exchangeName = "topicExchg", exchangeType = "topic"}
+    bindQueue chan "myQueueDE" "topicExchg" "de.*"
+    bindQueue chan "myQueueEN" "topicExchg" "en.*"
+
+    --publish messages
+    publishMsg chan "topicExchg" "de.hello"
+        (newMsg {msgBody = (BL.pack "hallo welt"),
+                 msgDeliveryMode = Just NonPersistent}
+                )
+    publishMsg chan "topicExchg" "en.hello"
+        (newMsg {msgBody = (BL.pack "hello world"),
+                 msgDeliveryMode = Just NonPersistent}
+                )
+
+
+    closeConnection conn


### PR DESCRIPTION
See examples/ExampleTLSClient.hs and examples/ExampleTLSServer.hs.
- Add coUseTLS labeled field to ConnectionOpts
- Switch from GHC.IO.Handle to Network.Connection
- Depends on unreleased connection-1.3-dev
- To build see: https://gist.github.com/AlainODea/7852276
