### PR TITLE
Add lifted version of consumeMsgs

### DIFF
--- a/Network/AMQP/Lifted.hs
+++ b/Network/AMQP/Lifted.hs
@@ -1,0 +1,42 @@
+{-# LANGUAGE FlexibleContexts #-}
+
+module Network.AMQP.Lifted
+       ( consumeMsgs
+       , consumeMsgs'
+       )
+       where
+
+import qualified Network.AMQP as A
+import Network.AMQP.Types
+import Control.Monad.Trans.Control
+import Data.Text (Text)
+import Control.Monad
+
+-- | @consumeMsgs chan queueName ack callback@ subscribes to the given queue and returns a consumerTag. For any incoming message, the callback will be run. If @ack == 'Ack'@ you will have to acknowledge all incoming messages (see 'ackMsg' and 'ackEnv')
+--
+-- NOTE: The callback will be run on the same thread as the channel thread (every channel spawns its own thread to listen for incoming data) so DO NOT perform any request on @chan@ inside the callback (however, you CAN perform requests on other open channels inside the callback, though I wouldn't recommend it).
+-- Functions that can safely be called on @chan@ are 'ackMsg', 'ackEnv', 'rejectMsg', 'recoverMsgs'. If you want to perform anything more complex, it's a good idea to wrap it inside 'forkIO'.
+--
+-- In addition, while the callback function @(('Message', 'Envelope') -> m ())@
+-- has access to the captured state, all its side-effects in m are discarded.
+consumeMsgs :: MonadBaseControl IO m
+            => A.Channel
+            -> Text -- ^ Specifies the name of the queue to consume from.
+            -> A.Ack
+            -> ((A.Message, A.Envelope) -> m ())
+            -> m A.ConsumerTag
+consumeMsgs chan queueName ack callback =
+    liftBaseWith $ \runInIO ->
+        A.consumeMsgs chan queueName ack (void . runInIO . callback)
+
+-- | an extended version of @consumeMsgs@ that allows you to include arbitrary arguments.
+consumeMsgs' :: MonadBaseControl IO m
+             => A.Channel
+             -> Text -- ^ Specifies the name of the queue to consume from.
+             -> A.Ack
+             -> ((A.Message, A.Envelope) -> m ())
+             -> FieldTable
+             -> m A.ConsumerTag
+consumeMsgs' chan queueName ack callback args =
+    liftBaseWith $ \runInIO ->
+        A.consumeMsgs' chan queueName ack (void . runInIO . callback) args

--- a/amqp.cabal
+++ b/amqp.cabal
@@ -18,8 +18,8 @@ Extra-source-files:  examples/ExampleConsumer.hs,
                      examples/ExampleProducer.hs
 
 Library
-  Build-Depends:      base >= 4 && < 5, binary >= 0.7, containers>=0.2, bytestring>=0.9, network>=2.2.3.1, data-binary-ieee754>=0.4.2.1, text>=0.11.2, split>=0.2, clock >= 0.4.0.1
-  Exposed-modules:    Network.AMQP, Network.AMQP.Types
+  Build-Depends:      base >= 4 && < 5, binary >= 0.7, containers>=0.2, bytestring>=0.9, network>=2.2.3.1, data-binary-ieee754>=0.4.2.1, text>=0.11.2, split>=0.2, clock >= 0.4.0.1, monad-control >= 0.3
+  Exposed-modules:    Network.AMQP, Network.AMQP.Types, Network.AMQP.Lifted
   Other-modules:      Network.AMQP.Generated, Network.AMQP.Helpers, Network.AMQP.Protocol, Network.AMQP.Internal
   GHC-Options:        -Wall
 


### PR DESCRIPTION
This PR adds wrapped version of `consumeMsgs` with type generalized to all monads in `MonadBaseControl IO`.
It is convenient when used with `LoggerT` and `ReaderT`.
