### PR TITLE
Network.URI moved

### DIFF
--- a/amqp.cabal
+++ b/amqp.cabal
@@ -24,6 +24,7 @@ Library
     containers>=0.2,
     bytestring>=0.9,
     network>=2.2.3.1,
+    network-uri>=2.6.0.0,
     data-binary-ieee754>=0.4.2.1,
     text>=0.11.2,
     split>=0.2,


### PR DESCRIPTION
From network-2.6.0.0 the namespace Network.URI moved to network-uri-2.6.0.0. Building amqp-0.10 gives the error
Could not find module `Network.URI'
It is a member of the hidden package`network-uri-2.6.0.0'.
Perhaps you need to add `network-uri' to the build-depends in your .cabal file
