### PR TITLE
Fix heartbeats validation logic

### DIFF
--- a/Network/AMQP/Helpers.hs
+++ b/Network/AMQP/Helpers.hs
@@ -4,7 +4,7 @@ module Network.AMQP.Helpers where
 import Control.Concurrent
 import Control.Monad
 import Data.Int (Int64)
-import System.Clock
+import System.Time
 
 import qualified Data.ByteString.Char8 as BS
 import qualified Data.ByteString.Lazy.Char8 as BL
@@ -42,11 +42,7 @@ chooseMin a (Just b) = min a b
 chooseMin a Nothing  = a
 
 getTimestamp :: IO Int64
-getTimestamp = fmap µs $ getTime Monotonic
-  where
-  	seconds spec = (fromIntegral . sec) spec * 1000 * 1000
-  	micros spec = (fromIntegral . nsec) spec `div` 1000
-  	µs spec = (seconds spec) + (micros spec)
+getTimestamp = getClockTime >>= \(TOD n m) -> return (read (show n ++ show m) :: Int64)
 
 scheduleAtFixedRate :: Int -> IO () -> IO ThreadId
 scheduleAtFixedRate interval_µs action = forkIO $ forever $ do

--- a/Network/AMQP/Internal.hs
+++ b/Network/AMQP/Internal.hs
@@ -345,7 +345,7 @@ watchHeartbeats conn timeout connThread = scheduleAtFixedRate rate $ do
 
     check var timeout_µs action = withMVar var $ \lastFrameTime -> do
         time <- getTimestamp
-        when (time >= lastFrameTime + timeout_µs) $ do
+        when (lastFrameTime > 0 && time >= lastFrameTime + timeout_µs) $ do
             action
 
 updateLastSent :: Connection -> IO ()

--- a/Network/AMQP/Internal.hs
+++ b/Network/AMQP/Internal.hs
@@ -345,7 +345,7 @@ watchHeartbeats conn timeout connThread = scheduleAtFixedRate rate $ do
 
     check var timeout_µs action = withMVar var $ \lastFrameTime -> do
         time <- getTimestamp
-        when (lastFrameTime > 0 && time >= lastFrameTime + timeout_µs) $ do
+        when (time >= lastFrameTime + timeout_µs) $ do
             action
 
 updateLastSent :: Connection -> IO ()

--- a/amqp.cabal
+++ b/amqp.cabal
@@ -30,7 +30,7 @@ Library
     data-binary-ieee754>=0.4.2.1,
     text>=0.11.2,
     split>=0.2,
-    clock >= 0.4.0.1,
+    old-time >= 1.1.0.2,
     monad-control >= 0.3,
     connection == 0.2.*,
     vector
@@ -80,7 +80,7 @@ test-suite spec
     , data-binary-ieee754>=0.4.2.1
     , text>=0.11.2
     , split>=0.2
-    , clock >= 0.4.0.1
+    , old-time >= 1.1.0.2
     , hspec              >= 1.3
     , hspec-expectations >= 0.3.3
     , connection == 0.2.*

--- a/bin/ci/before_build.bat
+++ b/bin/ci/before_build.bat
@@ -1,0 +1,25 @@
+@echo off
+
+:: ${RABBITMQCTL:="sudo rabbitmqctl"}
+:: ${RABBITMQ_PLUGINS:="sudo rabbitmq-plugins"}
+
+:: guest:guest has full access to /
+
+cmd /C rabbitmqctl add_vhost /
+cmd /C rabbitmqctl add_user guest guest
+cmd /C rabbitmqctl set_permissions -p / guest ".*" ".*" ".*"
+
+:: haskell_amqp:haskell_amqp_password has full access to haskell_amqp_testbed
+
+cmd /C rabbitmqctl add_vhost haskell_amqp_testbed
+cmd /C rabbitmqctl add_user haskell_amqp haskell_amqp_password
+cmd /C rabbitmqctl set_permissions -p haskell_amqp_testbed haskell_amqp ".*" ".*" ".*"
+
+:: guest:guest has full access to haskell_amqp_testbed
+
+cmd /C rabbitmqctl set_permissions -p haskell_amqp_testbed guest ".*" ".*" ".*"
+
+:: haskell_amqp_reader:reader_password has read access to haskell_amqp_testbed
+
+cmd /C rabbitmqctl add_user haskell_amqp_reader reader_password
+cmd /C rabbitmqctl set_permissions -p haskell_amqp_testbed haskell_amqp_reader "^---$" "^---$" ".*"


### PR DESCRIPTION
With regards to a discussion [here](https://github.com/hreinhardt/amqp/issues/25#issuecomment-69451912).
Only checks heartbeats if `lastFrameTime` is present, otherwise skipping running cleanup action.
Also added `before_build.bat` file to prep for run on Windows.