### PR TITLE
Implement the remaining content header fields for messages

### DIFF
--- a/Network/AMQP.hs
+++ b/Network/AMQP.hs
@@ -327,7 +327,7 @@ deleteQueue chan queue = do
 
 -- | a 'Msg' with defaults set; you should override at least 'msgBody'
 newMsg :: Message
-newMsg = Message (BL.empty) Nothing Nothing Nothing Nothing Nothing Nothing Nothing
+newMsg = Message (BL.empty) Nothing Nothing Nothing Nothing Nothing Nothing Nothing Nothing Nothing Nothing Nothing Nothing Nothing Nothing
 
 type ConsumerTag = Text
 
@@ -395,22 +395,21 @@ publishMsg' chan exchange routingKey mandatory msg = do
             mandatory -- mandatory; if true, the server might return the msg, which is currently not handled
             False) --immediate; not customizable, as it is currently not supported anymore by RabbitMQ
 
-            --TODO: add more of these to 'Message'
             (CHBasic
             (fmap ShortString $ msgContentType msg)
-            Nothing
+            (fmap ShortString $ msgContentEncoding msg)
             (msgHeaders msg)
             (fmap deliveryModeToInt $ msgDeliveryMode msg) -- delivery_mode
-            Nothing
+            (msgPriority msg)
             (fmap ShortString $ msgCorrelationID msg)
             (fmap ShortString $ msgReplyTo msg)
-            Nothing
+            (fmap ShortString $ msgExpiration msg)
             (fmap ShortString $ msgID msg)
             (msgTimestamp msg)
-            Nothing
-            Nothing
-            Nothing
-            Nothing
+            (fmap ShortString $ msgType msg)
+            (fmap ShortString $ msgUserID msg)
+            (fmap ShortString $ msgApplicationID msg)
+            (fmap ShortString $ msgClusterID msg)
             )
             (msgBody msg))
     return ()

--- a/Network/AMQP/Internal.hs
+++ b/Network/AMQP/Internal.hs
@@ -49,9 +49,16 @@ data Message = Message {
                 msgDeliveryMode :: Maybe DeliveryMode, -- ^ see 'DeliveryMode'
                 msgTimestamp :: Maybe Timestamp, -- ^ use in any way you like; this doesn't affect the way the message is handled
                 msgID :: Maybe Text, -- ^ use in any way you like; this doesn't affect the way the message is handled
+                msgType :: Maybe Text, -- ^ use in any way you like; this doesn't affect the way the message is handled
+                msgUserID :: Maybe Text,
+                msgApplicationID :: Maybe Text,
+                msgClusterID :: Maybe Text,
                 msgContentType :: Maybe Text,
+                msgContentEncoding :: Maybe Text,
                 msgReplyTo :: Maybe Text,
+                msgPriority :: Maybe Octet,
                 msgCorrelationID :: Maybe Text,
+                msgExpiration :: Maybe Text,
                 msgHeaders :: Maybe FieldTable
                 }
     deriving (Eq, Ord, Read, Show)
@@ -450,12 +457,17 @@ data Channel = Channel {
                 }
 
 msgFromContentHeaderProperties :: ContentHeaderProperties -> BL.ByteString -> Message
-msgFromContentHeaderProperties (CHBasic content_type _ headers delivery_mode _ correlation_id reply_to _ message_id timestamp _ _ _ _) body =
+msgFromContentHeaderProperties (CHBasic content_type content_encoding headers delivery_mode priority correlation_id reply_to expiration message_id timestamp message_type user_id application_id cluster_id) body =
     let msgId = fromShortString message_id
         contentType = fromShortString content_type
+        contentEncoding = fromShortString content_encoding
         replyTo = fromShortString reply_to
         correlationID = fromShortString correlation_id
-    in Message body (fmap intToDeliveryMode delivery_mode) timestamp msgId contentType replyTo correlationID headers
+        messageType = fromShortString message_type
+        userId = fromShortString user_id
+        applicationId = fromShortString application_id
+        clusterId = fromShortString cluster_id
+    in Message body (fmap intToDeliveryMode delivery_mode) timestamp msgId messageType userId applicationId clusterId contentType contentEncoding replyTo priority correlationID (fromShortString expiration) headers
   where
     fromShortString (Just (ShortString s)) = Just s
     fromShortString _ = Nothing


### PR DESCRIPTION
We use the type field quite a bit in our own code, but I went ahead and just implemented them all.

I wasn't quite sure if you were using some kind of special ordering of the fields in the `Message` type, so I just added them where it seemed to make sense. Let me know if you want them to be ordered differently and I can do that.