### PR TITLE
Implement support for RabbitMQ's publisher confirms

### DIFF
--- a/Network/AMQP/Types.hs
+++ b/Network/AMQP/Types.hs
@@ -17,11 +17,13 @@ module Network.AMQP.Types (
     FieldTable(..),
     FieldValue(..),
     Decimals,
-    DecimalValue(..)
+    DecimalValue(..),
+    ConfirmationResult(..),
 ) where
 
 import Control.Applicative
 import Data.Int
+import Data.IntSet (IntSet)
 import Data.Binary
 import Data.Binary.Get
 import Data.Binary.IEEE754
@@ -209,3 +211,5 @@ instance Binary DecimalValue where
     put (DecimalValue a b) = put a >> put b
 
 type Decimals = Octet
+
+data ConfirmationResult = Complete (IntSet, IntSet) | Partial (IntSet, IntSet, IntSet) deriving Show

--- a/amqp.cabal
+++ b/amqp.cabal
@@ -33,7 +33,8 @@ Library
     clock >= 0.4.0.1,
     monad-control >= 0.3,
     connection == 0.2.*,
-    vector
+    vector,
+    stm >= 2.4.0
   if flag(network-uri)
      build-depends: network-uri >= 2.6, network > 2.6
   else
@@ -85,6 +86,7 @@ test-suite spec
     , hspec-expectations >= 0.3.3
     , connection == 0.2.*
     , vector
+    , stm >= 2.4.0
   if flag(network-uri)
      build-depends: network-uri >= 2.6, network > 2.6
   else

--- a/examples/ExampleConfirms.hs
+++ b/examples/ExampleConfirms.hs
@@ -1,0 +1,39 @@
+{-# OPTIONS -XOverloadedStrings #-}
+import Network.AMQP
+import Control.Monad(forM_,forever)
+import Control.Concurrent(forkIO,threadDelay)
+import Control.Concurrent.Chan
+import Control.Concurrent.STM
+import Data.Time.Clock
+import Data.IntSet
+import qualified Data.ByteString.Lazy.Char8 as BL
+
+showResult :: ConfirmationResult -> IO ()
+showResult (Partial (a, n, p)) = putStrLn $ "Acks: "++(show . size $ a)++" Nacks: "++(show . size $ n)++" pending: "++(show . size $ p)
+showResult (Complete (a, n)) = putStrLn $ "Acks: "++(show . size $ a)++" Nacks: "++(show . size $ n)
+main = do
+    conn <- openConnection "localhost" "/" "guest" "guest"
+    chan <- openChannel conn
+
+    confirmSelect chan False
+
+    --declare queues and bindings
+    declareQueue chan newQueue {queueName = "myQueue", queueAutoDelete = True}
+    bindQueue chan "myQueue" "amq.topic" "conf.*"
+
+    --activate a consumer so that messages won't be returned
+    consumeMsgs chan "myQueue" Ack (\(msg,env) -> ackEnv env)
+
+    forkIO $ forever $ do
+      putStrLn "Publishing messages.."
+      forM_ [1..100] (\i -> publishMsg chan
+                            "amq.topic"
+                            "conf.hello"
+                            (newMsg {msgBody = (BL.pack "hallo welt"), msgDeliveryMode = Just NonPersistent})
+                     )
+      putStr "Waiting for confirms..."
+      showResult =<< waitForConfirms chan -- or waitForConfirmsUntil chan (10^6)
+      threadDelay (10^6)
+
+    getLine
+    closeConnection conn


### PR DESCRIPTION
The implementation follows in general lines the behaviour of the rabbitmq java client. There's an `addConfirmationListener` function, which registers a callback to be invoked each time the channel receives a confirmation from the server (either `Basic_ack` or `Basic_nack`). There's also a pair of functions: `waitForConfirms` (waits forever) and `waitForConfirms'` (waits with a timeout).