### PR TITLE
Kill channel thread when connection is closed during callback. #69

### DIFF
--- a/Network/AMQP.hs
+++ b/Network/AMQP.hs
@@ -131,6 +131,7 @@ module Network.AMQP (
 
     -- * Exceptions
     AMQPException(..),
+    ChanThreadKilledException,
 
     -- * URI parsing
     fromURI


### PR DESCRIPTION
Exceptions that occur within a subscriber callback are caught.
When a connection is closed, expectedly or unexpectedly, an exception is
thrown onto each channel thread to stop them. However, if that exception
is thrown while a subscription callback is executing, it gets caught,
the channel thread is never stopped and the channel exception handlers
are never run.

This fix wraps exceptions that should kill a channel thread and makes
sure they don't get caught.