### PR TITLE
Add Consumer Cancellation Notification support

### DIFF
--- a/Network/AMQP.hs
+++ b/Network/AMQP.hs
@@ -70,6 +70,7 @@ module Network.AMQP (
     Channel,
     openChannel,
     addReturnListener,
+    addConsumerCancellationListener,
     addChannelExceptionHandler,
     qos,
 
@@ -128,7 +129,7 @@ module Network.AMQP (
     addConfirmationListener,
     ConfirmationResult(..),
     AckType(..),
-    
+
     -- * Flow Control
     flow,
 
@@ -351,8 +352,6 @@ deleteQueue chan queue = do
 -- | a 'Msg' with defaults set; you should override at least 'msgBody'
 newMsg :: Message
 newMsg = Message (BL.empty) Nothing Nothing Nothing Nothing Nothing Nothing Nothing Nothing Nothing Nothing Nothing Nothing Nothing Nothing
-
-type ConsumerTag = Text
 
 -- | specifies whether you have to acknowledge messages that you receive from 'consumeMsgs' or 'getMsg'. If you use 'Ack', you have to call 'ackMsg' or 'ackEnv' after you have processed a message, otherwise it might be delivered again in the future
 data Ack = Ack | NoAck

--- a/Network/AMQP/Internal.hs
+++ b/Network/AMQP/Internal.hs
@@ -485,9 +485,9 @@ data Channel = Channel {
 
                     chanActive :: Lock, -- used for flow-control. if lock is closed, no content methods will be sent
                     chanClosed :: MVar (Maybe (CloseType, String)),
-                    consumers :: MVar (M.Map Text ((Message, Envelope) -> IO ())), -- who is consumer of a queue? (consumerTag => callback)
+                    consumers :: MVar (M.Map Text ((Message, Envelope) -> IO (),    -- who is consumer of a queue? (consumerTag => callback)
+                                                   (ConsumerTag -> IO ()))),        -- cancellation notification callback
                     returnListeners :: MVar ([(Message, PublishError) -> IO ()]),
-                    cancelListeners :: MVar ([ConsumerTag -> IO ()]),
                     confirmListeners :: MVar ([(Word64, Bool, AckType) -> IO ()]),
                     chanExceptionHandlers :: MVar [CE.SomeException -> IO ()]
                 }
@@ -554,7 +554,7 @@ channelReceiver chan = do
                                 properties body) =
         withMVar (consumers chan) (\s -> do
             case M.lookup consumerTag s of
-                Just subscriber -> do
+                Just (subscriber, _) -> do
                     let msg = msgFromContentHeaderProperties properties body
                     let env = Envelope {envDeliveryTag = deliveryTag, envRedelivered = redelivered,
                                     envExchangeName = exchange, envRoutingKey = routingKey, envChannel = chan}
@@ -610,10 +610,16 @@ channelReceiver chan = do
           modifyTVar' targetSet (\ts -> merge ts)
           writeTVar (unconfirmedSet chan) pending
 
-    handleCancel (ShortString consumerTag) = do
-        withMVar (cancelListeners chan) $ \listeners ->
-            forM_ listeners $ \l -> CE.catch (l consumerTag) $ \(ex :: CE.SomeException) ->
-                hPutStrLn stderr $ "consumer cancellation listener on channel ["++(show $ channelID chan)++"] threw exception: "++ show ex
+    handleCancel (ShortString consumerTag) =
+        withMVar (consumers chan) (\s -> do
+            case M.lookup consumerTag s of
+                Just (_, cancelCB) ->
+                    CE.catch (cancelCB consumerTag) $ \(ex :: CE.SomeException) ->
+                        hPutStrLn stderr $ "consumer cancellation listener "++(show consumerTag)++" on channel ["++(show $ channelID chan)++"] threw exception: "++ show ex
+                Nothing ->
+                    -- got a cancellation notification, but have no registered subscriber; so drop it
+                    return ()
+            )
 
     basicReturnToPublishError (Basic_return code (ShortString errText) (ShortString exchange) (ShortString routingKey)) =
         let replyError = case code of
@@ -629,13 +635,6 @@ channelReceiver chan = do
 addReturnListener :: Channel -> ((Message, PublishError) -> IO ()) -> IO ()
 addReturnListener chan listener = do
     modifyMVar_ (returnListeners chan) $ \listeners -> return $ listener:listeners
-
--- | registers a callback function that is called whenever a consumer is cancelled by the broker ('basic.cancel).
---
--- See https://www.rabbitmq.com/consumer-cancel.html
-addConsumerCancellationListener :: Channel -> (ConsumerTag -> IO ()) -> IO ()
-addConsumerCancellationListener chan listener = do
-    modifyMVar_ (cancelListeners chan) $ \listeners -> return $ listener:listeners
 
 -- | registers a callback function that is called whenever a channel is closed by an exception.
 addChannelExceptionHandler :: Channel -> (CE.SomeException -> IO ()) -> IO ()
@@ -676,7 +675,6 @@ openChannel c = do
     closed <- newMVar Nothing
     conss <- newMVar M.empty
     retListeners <- newMVar []
-    cancListeners <- newMVar []
     aSet <- newTVarIO IntSet.empty
     nSet <- newTVarIO IntSet.empty
     nxtSeq <- newMVar 0
@@ -687,7 +685,7 @@ openChannel c = do
     --add new channel to connection's channel map
     newChannel <- modifyMVar (connChannels c) $ \mp -> do
         newChannelID <- allocateChannel (connChanAllocator c)
-        let newChannel = Channel c newInQueue outRes (fromIntegral newChannelID) lastConsTag nxtSeq unconfSet aSet nSet ca closed conss retListeners cancListeners cnfListeners handlers
+        let newChannel = Channel c newInQueue outRes (fromIntegral newChannelID) lastConsTag nxtSeq unconfSet aSet nSet ca closed conss retListeners cnfListeners handlers
         thrID <- forkFinally' (channelReceiver newChannel) $ \res -> do
                    closeChannel' newChannel Normal "closed"
                    case res of

--- a/Network/AMQP/Internal.hs
+++ b/Network/AMQP/Internal.hs
@@ -585,7 +585,7 @@ channelReceiver chan = do
                 hPutStrLn stderr $ "return listener on channel ["++(show $ channelID chan)++"] handling error ["++show pubError++"] threw exception: "++show ex
     handleAsync (SimpleMethod (Basic_ack deliveryTag multiple)) = handleConfirm deliveryTag multiple BasicAck
     handleAsync (SimpleMethod (Basic_nack deliveryTag multiple _)) = handleConfirm deliveryTag multiple BasicNack
-    handleAsync (SimpleMethod (Basic_cancel deliveryTag _)) = handleCancel deliveryTag
+    handleAsync (SimpleMethod (Basic_cancel consumerTag _)) = handleCancel consumerTag
     handleAsync m = error ("Unknown method: " ++ show m)
 
     handleConfirm deliveryTag multiple k = do

--- a/Network/AMQP/Internal.hs
+++ b/Network/AMQP/Internal.hs
@@ -329,7 +329,10 @@ openConnection'' connOpts = withSocketsDo $ do
                                              (ShortString "en_US")) ))
                     where clientProperties = FieldTable $ M.fromList $ [ ("platform", FVString "Haskell")
                                                                        , ("version" , FVString . T.pack $ showVersion version)
+                                                                       , ("capabilities", FVFieldTable clientCapabilities)
                                                                        ] ++ maybe [] (\x -> [("connection_name", FVString x)]) (coName connOpts)
+
+                          clientCapabilities = FieldTable $ M.fromList $ [ ("consumer_cancel_notify", FVBool True) ]
 
     handleSecureUntilTune handle sasl = do
         tuneOrSecure <- readFrame handle
@@ -484,6 +487,7 @@ data Channel = Channel {
                     chanClosed :: MVar (Maybe (CloseType, String)),
                     consumers :: MVar (M.Map Text ((Message, Envelope) -> IO ())), -- who is consumer of a queue? (consumerTag => callback)
                     returnListeners :: MVar ([(Message, PublishError) -> IO ()]),
+                    cancelListeners :: MVar ([ConsumerTag -> IO ()]),
                     confirmListeners :: MVar ([(Word64, Bool, AckType) -> IO ()]),
                     chanExceptionHandlers :: MVar [CE.SomeException -> IO ()]
                 }
@@ -581,6 +585,7 @@ channelReceiver chan = do
                 hPutStrLn stderr $ "return listener on channel ["++(show $ channelID chan)++"] handling error ["++show pubError++"] threw exception: "++show ex
     handleAsync (SimpleMethod (Basic_ack deliveryTag multiple)) = handleConfirm deliveryTag multiple BasicAck
     handleAsync (SimpleMethod (Basic_nack deliveryTag multiple _)) = handleConfirm deliveryTag multiple BasicNack
+    handleAsync (SimpleMethod (Basic_cancel deliveryTag _)) = handleCancel deliveryTag
     handleAsync m = error ("Unknown method: " ++ show m)
 
     handleConfirm deliveryTag multiple k = do
@@ -604,6 +609,11 @@ channelReceiver chan = do
           modifyTVar' targetSet (\ts -> merge ts)
           writeTVar (unconfirmedSet chan) pending
 
+    handleCancel (ShortString deliveryTag) = do
+        withMVar (cancelListeners chan) $ \listeners ->
+            forM_ listeners $ \l -> CE.catch (l deliveryTag) $ \(ex :: CE.SomeException) ->
+                hPutStrLn stderr $ "cunsumer cancellation listener on channel ["++(show $ channelID chan)++"] threw exception: "++ show ex
+
     basicReturnToPublishError (Basic_return code (ShortString errText) (ShortString exchange) (ShortString routingKey)) =
         let replyError = case code of
                 312 -> Unroutable errText
@@ -618,6 +628,13 @@ channelReceiver chan = do
 addReturnListener :: Channel -> ((Message, PublishError) -> IO ()) -> IO ()
 addReturnListener chan listener = do
     modifyMVar_ (returnListeners chan) $ \listeners -> return $ listener:listeners
+
+-- | registers a callback function that is called whenever a consumer is cancelled by the broker ('basic.cancel).
+--
+-- See https://www.rabbitmq.com/consumer-cancel.html
+addConsumerCancellationListener :: Channel -> (ConsumerTag -> IO ()) -> IO ()
+addConsumerCancellationListener chan listener = do
+    modifyMVar_ (cancelListeners chan) $ \listeners -> return $ listener:listeners
 
 -- | registers a callback function that is called whenever a channel is closed by an exception.
 addChannelExceptionHandler :: Channel -> (CE.SomeException -> IO ()) -> IO ()
@@ -658,6 +675,7 @@ openChannel c = do
     closed <- newMVar Nothing
     conss <- newMVar M.empty
     retListeners <- newMVar []
+    cancListeners <- newMVar []
     aSet <- newTVarIO IntSet.empty
     nSet <- newTVarIO IntSet.empty
     nxtSeq <- newMVar 0
@@ -668,7 +686,7 @@ openChannel c = do
     --add new channel to connection's channel map
     newChannel <- modifyMVar (connChannels c) $ \mp -> do
         newChannelID <- allocateChannel (connChanAllocator c)
-        let newChannel = Channel c newInQueue outRes (fromIntegral newChannelID) lastConsTag nxtSeq unconfSet aSet nSet ca closed conss retListeners cnfListeners handlers
+        let newChannel = Channel c newInQueue outRes (fromIntegral newChannelID) lastConsTag nxtSeq unconfSet aSet nSet ca closed conss retListeners cancListeners cnfListeners handlers
         thrID <- forkFinally' (channelReceiver newChannel) $ \res -> do
                    closeChannel' newChannel Normal "closed"
                    case res of

--- a/Network/AMQP/Internal.hs
+++ b/Network/AMQP/Internal.hs
@@ -545,6 +545,7 @@ channelReceiver chan = do
     isResponse (SimpleMethod (Channel_close _ _ _ _)) = False
     isResponse (SimpleMethod (Basic_ack _ _)) = False
     isResponse (SimpleMethod (Basic_nack _ _ _)) = False
+    isResponse (SimpleMethod (Basic_cancel _ _)) = False
     isResponse _ = True
 
     --Basic.Deliver: forward msg to registered consumer

--- a/Network/AMQP/Internal.hs
+++ b/Network/AMQP/Internal.hs
@@ -613,7 +613,7 @@ channelReceiver chan = do
     handleCancel (ShortString consumerTag) = do
         withMVar (cancelListeners chan) $ \listeners ->
             forM_ listeners $ \l -> CE.catch (l consumerTag) $ \(ex :: CE.SomeException) ->
-                hPutStrLn stderr $ "cunsumer cancellation listener on channel ["++(show $ channelID chan)++"] threw exception: "++ show ex
+                hPutStrLn stderr $ "consumer cancellation listener on channel ["++(show $ channelID chan)++"] threw exception: "++ show ex
 
     basicReturnToPublishError (Basic_return code (ShortString errText) (ShortString exchange) (ShortString routingKey)) =
         let replyError = case code of

--- a/Network/AMQP/Internal.hs
+++ b/Network/AMQP/Internal.hs
@@ -609,9 +609,9 @@ channelReceiver chan = do
           modifyTVar' targetSet (\ts -> merge ts)
           writeTVar (unconfirmedSet chan) pending
 
-    handleCancel (ShortString deliveryTag) = do
+    handleCancel (ShortString consumerTag) = do
         withMVar (cancelListeners chan) $ \listeners ->
-            forM_ listeners $ \l -> CE.catch (l deliveryTag) $ \(ex :: CE.SomeException) ->
+            forM_ listeners $ \l -> CE.catch (l consumerTag) $ \(ex :: CE.SomeException) ->
                 hPutStrLn stderr $ "cunsumer cancellation listener on channel ["++(show $ channelID chan)++"] threw exception: "++ show ex
 
     basicReturnToPublishError (Basic_return code (ShortString errText) (ShortString exchange) (ShortString routingKey)) =

--- a/Network/AMQP/Internal.hs
+++ b/Network/AMQP/Internal.hs
@@ -485,9 +485,9 @@ data Channel = Channel {
 
                     chanActive :: Lock, -- used for flow-control. if lock is closed, no content methods will be sent
                     chanClosed :: MVar (Maybe (CloseType, String)),
-                    consumers :: MVar (M.Map Text ((Message, Envelope) -> IO ())), -- who is consumer of a queue? (consumerTag => callback)
+                    consumers :: MVar (M.Map Text ((Message, Envelope) -> IO (),    -- who is consumer of a queue? (consumerTag => callback)
+                                                   IO ())),                         -- cancellation notification callback
                     returnListeners :: MVar ([(Message, PublishError) -> IO ()]),
-                    cancelListeners :: MVar ([ConsumerTag -> IO ()]),
                     confirmListeners :: MVar ([(Word64, Bool, AckType) -> IO ()]),
                     chanExceptionHandlers :: MVar [CE.SomeException -> IO ()]
                 }
@@ -554,7 +554,7 @@ channelReceiver chan = do
                                 properties body) =
         withMVar (consumers chan) (\s -> do
             case M.lookup consumerTag s of
-                Just subscriber -> do
+                Just (subscriber, _) -> do
                     let msg = msgFromContentHeaderProperties properties body
                     let env = Envelope {envDeliveryTag = deliveryTag, envRedelivered = redelivered,
                                     envExchangeName = exchange, envRoutingKey = routingKey, envChannel = chan}
@@ -610,10 +610,18 @@ channelReceiver chan = do
           modifyTVar' targetSet (\ts -> merge ts)
           writeTVar (unconfirmedSet chan) pending
 
-    handleCancel (ShortString consumerTag) = do
-        withMVar (cancelListeners chan) $ \listeners ->
-            forM_ listeners $ \l -> CE.catch (l consumerTag) $ \(ex :: CE.SomeException) ->
-                hPutStrLn stderr $ "cunsumer cancellation listener on channel ["++(show $ channelID chan)++"] threw exception: "++ show ex
+    handleCancel (ShortString consumerTag) =
+        withMVar (consumers chan) (\s -> do
+            case M.lookup consumerTag s of
+                Just (_, cancelCB) ->
+                    CE.catch cancelCB onError
+                Nothing ->
+                    -- got a cancellation notification, but have no registered subscriber; so drop it
+                    return ()
+            )
+      where
+        onError :: CE.SomeException -> IO ()
+        onError ex = hPutStrLn stderr $ "cunsumer cancellation listener on channel ["++(show $ channelID chan)++"] threw exception: "++ show ex
 
     basicReturnToPublishError (Basic_return code (ShortString errText) (ShortString exchange) (ShortString routingKey)) =
         let replyError = case code of
@@ -629,13 +637,6 @@ channelReceiver chan = do
 addReturnListener :: Channel -> ((Message, PublishError) -> IO ()) -> IO ()
 addReturnListener chan listener = do
     modifyMVar_ (returnListeners chan) $ \listeners -> return $ listener:listeners
-
--- | registers a callback function that is called whenever a consumer is cancelled by the broker ('basic.cancel).
---
--- See https://www.rabbitmq.com/consumer-cancel.html
-addConsumerCancellationListener :: Channel -> (ConsumerTag -> IO ()) -> IO ()
-addConsumerCancellationListener chan listener = do
-    modifyMVar_ (cancelListeners chan) $ \listeners -> return $ listener:listeners
 
 -- | registers a callback function that is called whenever a channel is closed by an exception.
 addChannelExceptionHandler :: Channel -> (CE.SomeException -> IO ()) -> IO ()
@@ -676,7 +677,6 @@ openChannel c = do
     closed <- newMVar Nothing
     conss <- newMVar M.empty
     retListeners <- newMVar []
-    cancListeners <- newMVar []
     aSet <- newTVarIO IntSet.empty
     nSet <- newTVarIO IntSet.empty
     nxtSeq <- newMVar 0
@@ -687,7 +687,7 @@ openChannel c = do
     --add new channel to connection's channel map
     newChannel <- modifyMVar (connChannels c) $ \mp -> do
         newChannelID <- allocateChannel (connChanAllocator c)
-        let newChannel = Channel c newInQueue outRes (fromIntegral newChannelID) lastConsTag nxtSeq unconfSet aSet nSet ca closed conss retListeners cancListeners cnfListeners handlers
+        let newChannel = Channel c newInQueue outRes (fromIntegral newChannelID) lastConsTag nxtSeq unconfSet aSet nSet ca closed conss retListeners cnfListeners handlers
         thrID <- forkFinally' (channelReceiver newChannel) $ \res -> do
                    closeChannel' newChannel Normal "closed"
                    case res of

--- a/Network/AMQP/Lifted.hs
+++ b/Network/AMQP/Lifted.hs
@@ -29,14 +29,15 @@ consumeMsgs chan queueName ack callback =
     liftBaseWith $ \runInIO ->
         A.consumeMsgs chan queueName ack (void . runInIO . callback)
 
--- | an extended version of @consumeMsgs@ that allows you to include arbitrary arguments.
+-- | an extended version of @consumeMsgs@ that allows you to define a consumer cancellation callback and include arbitrary arguments.
 consumeMsgs' :: MonadBaseControl IO m
              => A.Channel
              -> Text -- ^ Specifies the name of the queue to consume from.
              -> A.Ack
              -> ((A.Message, A.Envelope) -> m ())
+             -> (ConsumerTag -> m ())
              -> FieldTable
              -> m A.ConsumerTag
-consumeMsgs' chan queueName ack callback args =
+consumeMsgs' chan queueName ack callback cancelled args =
     liftBaseWith $ \runInIO ->
-        A.consumeMsgs' chan queueName ack (void . runInIO . callback) args
+        A.consumeMsgs' chan queueName ack (void . runInIO . callback) (void . runInIO . cancelled) args

--- a/Network/AMQP/Types.hs
+++ b/Network/AMQP/Types.hs
@@ -13,6 +13,7 @@ module Network.AMQP.Types (
     LongLongInt,
     ShortString(..),
     LongString(..),
+    ConsumerTag,
     Timestamp,
     FieldTable(..),
     FieldValue(..),
@@ -78,6 +79,8 @@ type PayloadSize = LongInt
 type ShortInt = Word16
 type LongInt = Word32
 type LongLongInt = Word64
+
+type ConsumerTag = Text
 
 newtype ShortString = ShortString Text
     deriving (Eq, Ord, Read, Show)


### PR DESCRIPTION
- clients now signal capabilty consumer_cancel_notify to the server
- new function addConsumerCancellationListener to register listeners
- listeners have type ConsumerTag -> IO ()