### PR TITLE
Add `getServerProperties` to obtain RabbitMQ server properties

### DIFF
--- a/Network/AMQP.hs
+++ b/Network/AMQP.hs
@@ -65,6 +65,7 @@ module Network.AMQP (
     closeChannel,
     closeConnection,
     addConnectionClosedHandler,
+    getServerProperties,
 
     -- * Channel
     Channel,


### PR DESCRIPTION
I had a look at the server properties during testing of consumer cancellation, found that there currently is no way to retrieve them in the amqp library, and added `getServerProperties` in accordance with the Java client, see https://www.rabbitmq.com/releases/rabbitmq-java-client/current-javadoc/com/rabbitmq/client/Connection.html

I've taken care to ensure this pull request and #80 merge without conflicts.