### PR TITLE
Connection blocked

### DIFF
--- a/Network/AMQP.hs
+++ b/Network/AMQP.hs
@@ -65,6 +65,7 @@ module Network.AMQP (
     closeChannel,
     closeConnection,
     addConnectionClosedHandler,
+    addConnectionBlockedHandler,
     getServerProperties,
 
     -- * Channel

--- a/Network/AMQP/Generated.hs
+++ b/Network/AMQP/Generated.hs
@@ -110,6 +110,8 @@ instance Binary MethodPayload where
     put (Connection_open_ok a) = putWord16be 10 >> putWord16be 41 >> put a
     put (Connection_close a b c d) = putWord16be 10 >> putWord16be 50 >> put a >> put b >> put c >> put d
     put Connection_close_ok = putWord16be 10 >> putWord16be 51
+    put (Connection_blocked a) = putWord16be 10 >> putWord16be 60 >> put a
+    put Connection_unblocked = putWord16be 10 >> putWord16be 61
     put (Channel_open a) = putWord16be 20 >> putWord16be 10 >> put a
     put (Channel_open_ok a) = putWord16be 20 >> putWord16be 11 >> put a
     put (Channel_flow a) = putWord16be 20 >> putWord16be 20 >> put a
@@ -174,6 +176,8 @@ instance Binary MethodPayload where
             (10,41) -> get >>= \a ->  return (Connection_open_ok a)
             (10,50) -> get >>= \a -> get >>= \b -> get >>= \c -> get >>= \d ->  return (Connection_close a b c d)
             (10,51) ->  return Connection_close_ok
+            (10,60) -> get >>= \a ->  return (Connection_blocked a)
+            (10,61) ->  return Connection_unblocked
             (20,10) -> get >>= \a ->  return (Channel_open a)
             (20,11) -> get >>= \a ->  return (Channel_open_ok a)
             (20,20) -> get >>= \a ->  return (Channel_flow a)
@@ -271,6 +275,12 @@ data MethodPayload =
         ShortInt -- method-id
     |
     Connection_close_ok
+
+    |
+    Connection_blocked
+        ShortString -- reason
+    |
+    Connection_unblocked
 
     |
     Channel_open

--- a/Network/AMQP/Internal.hs
+++ b/Network/AMQP/Internal.hs
@@ -647,7 +647,7 @@ channelReceiver chan = do
     handleUnblocked = do
         withMVar (connBlockedHandlers $ connection chan) $ \listeners ->
             forM_ listeners $ \(_, l) -> CE.catch l $ \(ex :: CE.SomeException) ->
-                hPutStrLn stderr $ "connection blocked listener on channel ["++(show $ channelID chan)++"] threw exception: "++ show ex
+                hPutStrLn stderr $ "connection unblocked listener on channel ["++(show $ channelID chan)++"] threw exception: "++ show ex
 
     basicReturnToPublishError (Basic_return code (ShortString errText) (ShortString exchange) (ShortString routingKey)) =
         let replyError = case code of

--- a/Tools/amqp0-9-1.xml
+++ b/Tools/amqp0-9-1.xml
@@ -10,6 +10,9 @@
      the ability for the Server to send basic.ack, basic.nack and
       basic.cancel to the client, and
      the un-deprecation of exchange.declare{auto-delete} and exchange.declare{internal}
+
+     Modifications are (c) 2010-2013 VMware, Inc. and may be distributed under
+     the same BSD license as the stripped spec.
 -->
 
 <!--
@@ -892,6 +895,24 @@
       </rule>
       <chassis name = "client" implement = "MUST" />
       <chassis name = "server" implement = "MUST" />
+    </method>
+
+    <method name = "blocked" index = "60">
+      <doc>
+        This method indicates that a connection has been blocked
+        and does not accept new publishes.
+      </doc>
+      <chassis name = "server" implement = "MUST"/>
+      <chassis name = "client" implement = "MUST"/>
+      <field name = "reason" domain = "shortstr" />
+    </method>
+    <method name = "unblocked" index = "61">
+      <doc>
+        This method indicates that a connection has been unblocked
+        and now accepts publishes.
+      </doc>
+      <chassis name = "server" implement = "MUST"/>
+      <chassis name = "client" implement = "MUST"/>
     </method>
   </class>
 
@@ -2433,8 +2454,14 @@
 
       <field name = "global" domain = "bit" label = "apply to entire connection">
         <doc>
-          By default the QoS settings apply to the current channel only. If this field is
-          set, they are applied to the entire connection.
+          RabbitMQ has reinterpreted this field. The original
+          specification said: "By default the QoS settings apply to
+          the current channel only. If this field is set, they are
+          applied to the entire connection." Instead, RabbitMQ takes
+          global=false to mean that the QoS settings should apply
+          per-consumer (for new consumers on the channel; existing
+          ones being unaffected) and global=true to mean that the QoS
+          settings should apply per-channel.
         </doc>
       </field>
     </method>
@@ -2570,7 +2597,7 @@
         corresponding basic.cancel from the client). This allows
         clients to be notified of the loss of consumers due to events
         such as queue deletion. Note that as it is not a MUST for
-        clients to accept this method from the client, it is advisable
+        clients to accept this method from the server, it is advisable
         for the broker to be able to identify those clients that are
         capable of accepting the method, through some means of
         capability negotiation.
@@ -3230,7 +3257,7 @@
   <class name = "confirm" handler = "channel" index = "85" label = "work with confirms">
     <doc>
       The Confirm class allows publishers to put the channel in
-      confirm mode and susequently be notified when messages have been
+      confirm mode and subsequently be notified when messages have been
       handled by the broker.  The intention is that all messages
       published on a channel in confirm mode will be acknowledged at
       some point.  By acknowledging a message the broker assumes


### PR DESCRIPTION
New function `addConnectionBlockedHandler` adds a new pair of blocked/unblocked handlers for a given connection - see https://www.rabbitmq.com/connection-blocked.html

The amqp messages `connection.blocked` and `connection.unblocked` have been missing from the protocol XML, so a new version has been downloaded from https://www.rabbitmq.com/protocol.html - i.e. the full machine-readable spec https://www.rabbitmq.com/resources/specs/amqp0-9-1.extended.xml.

Connection establishment and messaging has been tested against RabbitMQ 3.4.4, 3.5.7, 3.6.12 - in order to see the blocked/unblocked notifications a method has to be found to constrain the RabbitMQ server sufficiently to provoke connection blocking.