### PR TITLE
1733 ha multi broker fromuri

### DIFF
--- a/Network/AMQP.hs
+++ b/Network/AMQP.hs
@@ -691,17 +691,18 @@ qos chan prefetchSize prefetchCount global = do
 -- | Any of these fields may be empty and will be replaced with defaults from @amqp://guest:guest@localhost:5672/@
 fromURI :: String -> ConnectionOpts
 fromURI uri = defaultConnectionOpts {
-    coServers = hostPorts',
-    coVHost = (T.pack vhost),
-    coAuth = [plain (T.pack uid) (T.pack pw)]
+    coServers     = hostPorts',
+    coVHost       = (T.pack vhost),
+    coAuth        = [plain (T.pack uid) (T.pack pw)],
+    coTLSSettings = if tls then Just TLSTrusted else Nothing
   }
-  where (hostPorts, uid, pw, vhost) = fromURI' uri
+  where (hostPorts, uid, pw, vhost, tls) = fromURI' uri
         hostPorts' = [(h, fromIntegral p) | (h, p) <- hostPorts]
 
-fromURI' :: String -> ([(String, Int)], String, String, String)
+fromURI' :: String -> ([(String, Int)], String, String, String, Bool)
 fromURI' uri = (fromHostPort dport <$> hstPorts,
     unEscapeString (dropWhile (=='/') uid), unEscapeString pw,
-    unEscapeString vhost)
+    unEscapeString vhost, tls)
   where (pre :suf  :    _) = splitOn "@" (uri ++ "@" ) -- look mom, no regexp dependencies
         (pro :uid' :pw':_) = splitOn ":" (pre ++ "::")
         (hnp :thost:    _) = splitOn "/" (suf ++ "/" )
@@ -710,6 +711,7 @@ fromURI' uri = (fromHostPort dport <$> hstPorts,
         dport = if pro == "amqps" then 5671    else 5672
         uid   = if null uid'      then "guest" else uid'
         pw    = if null pw'       then "guest" else pw'
+        tls   = pro == "amqps"
 
 fromHostPort :: Int -> String -> (String, Int)
 fromHostPort dport hostPort = (unEscapeString host, nport)

--- a/Network/AMQP.hs
+++ b/Network/AMQP.hs
@@ -691,21 +691,29 @@ qos chan prefetchSize prefetchCount global = do
 -- | Any of these fields may be empty and will be replaced with defaults from @amqp://guest:guest@localhost:5672/@
 fromURI :: String -> ConnectionOpts
 fromURI uri = defaultConnectionOpts {
-    coServers = [(host,fromIntegral nport)],
+    coServers = hostPorts',
     coVHost = (T.pack vhost),
     coAuth = [plain (T.pack uid) (T.pack pw)]
   }
-  where (host,nport,uid,pw,vhost) = fromURI' uri
+  where (hostPorts, uid, pw, vhost) = fromURI' uri
+        hostPorts' = [(h, fromIntegral p) | (h, p) <- hostPorts]
 
-fromURI' :: String -> (String,Int,String,String,String)
-fromURI' uri = (unEscapeString host, nport, unEscapeString (dropWhile (=='/') uid), unEscapeString pw, unEscapeString vhost)
+fromURI' :: String -> ([(String, Int)], String, String, String)
+fromURI' uri = (fromHostPort dport <$> hstPorts,
+    unEscapeString (dropWhile (=='/') uid), unEscapeString pw,
+    unEscapeString vhost)
   where (pre :suf  :    _) = splitOn "@" (uri ++ "@" ) -- look mom, no regexp dependencies
         (pro :uid' :pw':_) = splitOn ":" (pre ++ "::")
         (hnp :thost:    _) = splitOn "/" (suf ++ "/" )
-        (hst':port :    _) = splitOn ":" (hnp ++ ":" )
+        hstPorts           = splitOn "," hnp
         vhost = if null thost     then "/"     else thost
         dport = if pro == "amqps" then 5671    else 5672
-        nport = if null port      then dport   else read port
         uid   = if null uid'      then "guest" else uid'
         pw    = if null pw'       then "guest" else pw'
-        host  = if null hst'      then "localhost" else hst'
+
+fromHostPort :: Int -> String -> (String, Int)
+fromHostPort dport hostPort = (unEscapeString host, nport)
+    where
+        (hst':port :    _) = splitOn ":" (hostPort ++ ":" )
+        host  = if null hst' then "localhost" else hst'
+        nport = if null port then dport       else read port

--- a/test/FromURISpec.hs
+++ b/test/FromURISpec.hs
@@ -33,9 +33,33 @@ spec = do
             (saslInitialResponse <$> coAuth o) `shouldBe` ["\NULu\NULp"]
             (isNothing $ coTLSSettings o) `shouldBe` True
         
+        it "amqp auth host-2" $ do
+            let o = fromURI "amqp://u:p@127.0.0.1,127.0.0.2"
+            coServers o `shouldBe` [("127.0.0.1", 5672),("127.0.0.2", 5672)]
+            coVHost o `shouldBe` "/"
+            (saslName <$> coAuth o) `shouldBe` ["PLAIN"]
+            (saslInitialResponse <$> coAuth o) `shouldBe` ["\NULu\NULp"]
+            (isNothing $ coTLSSettings o) `shouldBe` True
+        
         it "amqp auth host port" $ do
             let o = fromURI "amqp://u:p@127.0.0.1:5672"
             coServers o `shouldBe` [("127.0.0.1", 5672)]
+            coVHost o `shouldBe` "/"
+            (saslName <$> coAuth o) `shouldBe` ["PLAIN"]
+            (saslInitialResponse <$> coAuth o) `shouldBe` ["\NULu\NULp"]
+            (isNothing $ coTLSSettings o) `shouldBe` True
+        
+        it "amqp auth host-2 port" $ do
+            let o = fromURI "amqp://u:p@127.0.0.1,127.0.0.2:5672"
+            coServers o `shouldBe` [("127.0.0.1", 5672),("127.0.0.2", 5672)]
+            coVHost o `shouldBe` "/"
+            (saslName <$> coAuth o) `shouldBe` ["PLAIN"]
+            (saslInitialResponse <$> coAuth o) `shouldBe` ["\NULu\NULp"]
+            (isNothing $ coTLSSettings o) `shouldBe` True
+        
+        it "amqp auth host-2 port-2" $ do
+            let o = fromURI "amqp://u:p@127.0.0.1:5672,127.0.0.2:5672"
+            coServers o `shouldBe` [("127.0.0.1", 5672),("127.0.0.2", 5672)]
             coVHost o `shouldBe` "/"
             (saslName <$> coAuth o) `shouldBe` ["PLAIN"]
             (saslInitialResponse <$> coAuth o) `shouldBe` ["\NULu\NULp"]
@@ -49,6 +73,22 @@ spec = do
             (saslInitialResponse <$> coAuth o) `shouldBe` ["\NULu\NULp"]
             (isNothing $ coTLSSettings o) `shouldBe` True
         
+        it "amqp auth host-2 port-2 vhost" $ do
+            let o = fromURI "amqp://u:p@127.0.0.1:5673,127.0.0.2:5674/v"
+            coServers o `shouldBe` [("127.0.0.1", 5673),("127.0.0.2", 5674)]
+            coVHost o `shouldBe` "v"
+            (saslName <$> coAuth o) `shouldBe` ["PLAIN"]
+            (saslInitialResponse <$> coAuth o) `shouldBe` ["\NULu\NULp"]
+            (isNothing $ coTLSSettings o) `shouldBe` True
+        
+        it "amqp auth host-3 port-3 vhost" $ do
+            let o = fromURI "amqp://a:b@h1:8001,h2:8002,h3:8003/w"
+            coServers o `shouldBe` [("h1", 8001),("h2", 8002),("h3", 8003)]
+            coVHost o `shouldBe` "w"
+            (saslName <$> coAuth o) `shouldBe` ["PLAIN"]
+            (saslInitialResponse <$> coAuth o) `shouldBe` ["\NULa\NULb"]
+            (isNothing $ coTLSSettings o) `shouldBe` True
+        
         it "amqp host" $ do
             let o = fromURI "amqp://127.0.0.1"
             -- this appears to break: user host
@@ -59,9 +99,28 @@ spec = do
                 ["\NUL127.0.0.1\NULguest"]
             (isNothing $ coTLSSettings o) `shouldBe` True
         
+        it "amqp host-2" $ do
+            let o = fromURI "amqp://127.0.0.1,127.0.0.2"
+            -- this appears to break: user host
+            coServers o `shouldBe` [("localhost", 5672)]
+            coVHost o `shouldBe` "/"
+            (saslName <$> coAuth o) `shouldBe` ["PLAIN"]
+            (saslInitialResponse <$> coAuth o) `shouldBe`
+                ["\NUL127.0.0.1,127.0.0.2\NULguest"]
+            (isNothing $ coTLSSettings o) `shouldBe` True
+        
         it "amqps auth host" $ do
             let o = fromURI "amqps://u:p@127.0.0.1"
             coServers o `shouldBe` [("127.0.0.1", 5671)]
+            coVHost o `shouldBe` "/"
+            (saslName <$> coAuth o) `shouldBe` ["PLAIN"]
+            (saslInitialResponse <$> coAuth o) `shouldBe` ["\NULu\NULp"]
+            -- amqps protocol does not activate TLS!
+            (isNothing $ coTLSSettings o) `shouldBe` True
+        
+        it "amqps auth host-2" $ do
+            let o = fromURI "amqps://u:p@127.0.0.1,127.0.0.2"
+            coServers o `shouldBe` [("127.0.0.1", 5671),("127.0.0.2", 5671)]
             coVHost o `shouldBe` "/"
             (saslName <$> coAuth o) `shouldBe` ["PLAIN"]
             (saslInitialResponse <$> coAuth o) `shouldBe` ["\NULu\NULp"]
@@ -77,9 +136,36 @@ spec = do
             -- amqps protocol does not activate TLS!
             (isNothing $ coTLSSettings o) `shouldBe` True
         
+        it "amqps auth host-2 port" $ do
+            let o = fromURI "amqps://u:p@127.0.0.1,127.0.0.1:5673"
+            coServers o `shouldBe` [("127.0.0.1", 5671),("127.0.0.1", 5673)]
+            coVHost o `shouldBe` "/"
+            (saslName <$> coAuth o) `shouldBe` ["PLAIN"]
+            (saslInitialResponse <$> coAuth o) `shouldBe` ["\NULu\NULp"]
+            -- amqps protocol does not activate TLS!
+            (isNothing $ coTLSSettings o) `shouldBe` True
+        
+        it "amqps auth host-2 port-2" $ do
+            let o = fromURI "amqps://u:p@127.0.0.1:5672,127.0.0.1:5673"
+            coServers o `shouldBe` [("127.0.0.1", 5672),("127.0.0.1", 5673)]
+            coVHost o `shouldBe` "/"
+            (saslName <$> coAuth o) `shouldBe` ["PLAIN"]
+            (saslInitialResponse <$> coAuth o) `shouldBe` ["\NULu\NULp"]
+            -- amqps protocol does not activate TLS!
+            (isNothing $ coTLSSettings o) `shouldBe` True
+        
         it "amqps auth host port vhost" $ do
             let o = fromURI "amqps://u:p@127.0.0.1:5672/v"
             coServers o `shouldBe` [("127.0.0.1", 5672)]
+            coVHost o `shouldBe` "v"
+            (saslName <$> coAuth o) `shouldBe` ["PLAIN"]
+            (saslInitialResponse <$> coAuth o) `shouldBe` ["\NULu\NULp"]
+            -- amqps protocol does not activate TLS!
+            (isNothing $ coTLSSettings o) `shouldBe` True
+        
+        it "amqps auth host-2 port-2 vhost" $ do
+            let o = fromURI "amqps://u:p@127.0.0.1:5672,127.0.0.2:5673/v"
+            coServers o `shouldBe` [("127.0.0.1", 5672),("127.0.0.2", 5673)]
             coVHost o `shouldBe` "v"
             (saslName <$> coAuth o) `shouldBe` ["PLAIN"]
             (saslInitialResponse <$> coAuth o) `shouldBe` ["\NULu\NULp"]
@@ -94,5 +180,16 @@ spec = do
             (saslName <$> coAuth o) `shouldBe` ["PLAIN"]
             (saslInitialResponse <$> coAuth o) `shouldBe`
                 ["\NUL127.0.0.1\NULguest"]
+            -- amqps protocol does not activate TLS!
+            (isNothing $ coTLSSettings o) `shouldBe` True
+        
+        it "amqps host-2" $ do
+            let o = fromURI "amqps://127.0.0.1,127.0.0.2"
+            -- this appears to break: user host
+            coServers o `shouldBe` [("localhost", 5671)]
+            coVHost o `shouldBe` "/"
+            (saslName <$> coAuth o) `shouldBe` ["PLAIN"]
+            (saslInitialResponse <$> coAuth o) `shouldBe`
+                ["\NUL127.0.0.1,127.0.0.2\NULguest"]
             -- amqps protocol does not activate TLS!
             (isNothing $ coTLSSettings o) `shouldBe` True

--- a/test/FromURISpec.hs
+++ b/test/FromURISpec.hs
@@ -1,0 +1,98 @@
+{-# OPTIONS -XOverloadedStrings #-}
+
+
+module FromURISpec (main, spec) where
+
+
+import              Data.Maybe                              (isNothing)
+import              Network.AMQP
+import              Test.Hspec
+
+
+main :: IO ()
+main = hspec spec
+
+spec :: Spec
+spec = do
+    describe "fromURI" $ do
+        it "empty" $ do
+            let o = fromURI ""
+            coServers o `shouldBe` [("localhost", 5672)]
+            coVHost o `shouldBe` "/"
+            -- avoid undefined SASLMechanism Show instance
+            (saslName <$> coAuth o) `shouldBe` ["PLAIN"]
+            (saslInitialResponse <$> coAuth o) `shouldBe` ["\NULguest\NULguest"]
+            -- avoid undefined TLSSettings Show instance
+            (isNothing $ coTLSSettings o) `shouldBe` True
+        
+        it "amqp auth host" $ do
+            let o = fromURI "amqp://u:p@127.0.0.1"
+            coServers o `shouldBe` [("127.0.0.1", 5672)]
+            coVHost o `shouldBe` "/"
+            (saslName <$> coAuth o) `shouldBe` ["PLAIN"]
+            (saslInitialResponse <$> coAuth o) `shouldBe` ["\NULu\NULp"]
+            (isNothing $ coTLSSettings o) `shouldBe` True
+        
+        it "amqp auth host port" $ do
+            let o = fromURI "amqp://u:p@127.0.0.1:5672"
+            coServers o `shouldBe` [("127.0.0.1", 5672)]
+            coVHost o `shouldBe` "/"
+            (saslName <$> coAuth o) `shouldBe` ["PLAIN"]
+            (saslInitialResponse <$> coAuth o) `shouldBe` ["\NULu\NULp"]
+            (isNothing $ coTLSSettings o) `shouldBe` True
+        
+        it "amqp auth host port vhost" $ do
+            let o = fromURI "amqp://u:p@127.0.0.1:5672/v"
+            coServers o `shouldBe` [("127.0.0.1", 5672)]
+            coVHost o `shouldBe` "v"
+            (saslName <$> coAuth o) `shouldBe` ["PLAIN"]
+            (saslInitialResponse <$> coAuth o) `shouldBe` ["\NULu\NULp"]
+            (isNothing $ coTLSSettings o) `shouldBe` True
+        
+        it "amqp host" $ do
+            let o = fromURI "amqp://127.0.0.1"
+            -- this appears to break: user host
+            coServers o `shouldBe` [("localhost", 5672)]
+            coVHost o `shouldBe` "/"
+            (saslName <$> coAuth o) `shouldBe` ["PLAIN"]
+            (saslInitialResponse <$> coAuth o) `shouldBe`
+                ["\NUL127.0.0.1\NULguest"]
+            (isNothing $ coTLSSettings o) `shouldBe` True
+        
+        it "amqps auth host" $ do
+            let o = fromURI "amqps://u:p@127.0.0.1"
+            coServers o `shouldBe` [("127.0.0.1", 5671)]
+            coVHost o `shouldBe` "/"
+            (saslName <$> coAuth o) `shouldBe` ["PLAIN"]
+            (saslInitialResponse <$> coAuth o) `shouldBe` ["\NULu\NULp"]
+            -- amqps protocol does not activate TLS!
+            (isNothing $ coTLSSettings o) `shouldBe` True
+        
+        it "amqps auth host port" $ do
+            let o = fromURI "amqps://u:p@127.0.0.1:5672"
+            coServers o `shouldBe` [("127.0.0.1", 5672)]
+            coVHost o `shouldBe` "/"
+            (saslName <$> coAuth o) `shouldBe` ["PLAIN"]
+            (saslInitialResponse <$> coAuth o) `shouldBe` ["\NULu\NULp"]
+            -- amqps protocol does not activate TLS!
+            (isNothing $ coTLSSettings o) `shouldBe` True
+        
+        it "amqps auth host port vhost" $ do
+            let o = fromURI "amqps://u:p@127.0.0.1:5672/v"
+            coServers o `shouldBe` [("127.0.0.1", 5672)]
+            coVHost o `shouldBe` "v"
+            (saslName <$> coAuth o) `shouldBe` ["PLAIN"]
+            (saslInitialResponse <$> coAuth o) `shouldBe` ["\NULu\NULp"]
+            -- amqps protocol does not activate TLS!
+            (isNothing $ coTLSSettings o) `shouldBe` True
+        
+        it "amqps host" $ do
+            let o = fromURI "amqps://127.0.0.1"
+            -- this appears to break: user host
+            coServers o `shouldBe` [("localhost", 5671)]
+            coVHost o `shouldBe` "/"
+            (saslName <$> coAuth o) `shouldBe` ["PLAIN"]
+            (saslInitialResponse <$> coAuth o) `shouldBe`
+                ["\NUL127.0.0.1\NULguest"]
+            -- amqps protocol does not activate TLS!
+            (isNothing $ coTLSSettings o) `shouldBe` True

--- a/test/FromURISpec.hs
+++ b/test/FromURISpec.hs
@@ -4,7 +4,6 @@
 module FromURISpec (main, spec) where
 
 
-import              Data.Maybe                              (isNothing)
 import              Network.AMQP
 import              Test.Hspec
 
@@ -23,7 +22,7 @@ spec = do
             (saslName <$> coAuth o) `shouldBe` ["PLAIN"]
             (saslInitialResponse <$> coAuth o) `shouldBe` ["\NULguest\NULguest"]
             -- avoid undefined TLSSettings Show instance
-            (isNothing $ coTLSSettings o) `shouldBe` True
+            (isTrusted $ coTLSSettings o) `shouldBe` False
         
         it "amqp auth host" $ do
             let o = fromURI "amqp://u:p@127.0.0.1"
@@ -31,7 +30,7 @@ spec = do
             coVHost o `shouldBe` "/"
             (saslName <$> coAuth o) `shouldBe` ["PLAIN"]
             (saslInitialResponse <$> coAuth o) `shouldBe` ["\NULu\NULp"]
-            (isNothing $ coTLSSettings o) `shouldBe` True
+            (isTrusted $ coTLSSettings o) `shouldBe` False
         
         it "amqp auth host-2" $ do
             let o = fromURI "amqp://u:p@127.0.0.1,127.0.0.2"
@@ -39,7 +38,7 @@ spec = do
             coVHost o `shouldBe` "/"
             (saslName <$> coAuth o) `shouldBe` ["PLAIN"]
             (saslInitialResponse <$> coAuth o) `shouldBe` ["\NULu\NULp"]
-            (isNothing $ coTLSSettings o) `shouldBe` True
+            (isTrusted $ coTLSSettings o) `shouldBe` False
         
         it "amqp auth host port" $ do
             let o = fromURI "amqp://u:p@127.0.0.1:5672"
@@ -47,7 +46,7 @@ spec = do
             coVHost o `shouldBe` "/"
             (saslName <$> coAuth o) `shouldBe` ["PLAIN"]
             (saslInitialResponse <$> coAuth o) `shouldBe` ["\NULu\NULp"]
-            (isNothing $ coTLSSettings o) `shouldBe` True
+            (isTrusted $ coTLSSettings o) `shouldBe` False
         
         it "amqp auth host-2 port" $ do
             let o = fromURI "amqp://u:p@127.0.0.1,127.0.0.2:5672"
@@ -55,7 +54,7 @@ spec = do
             coVHost o `shouldBe` "/"
             (saslName <$> coAuth o) `shouldBe` ["PLAIN"]
             (saslInitialResponse <$> coAuth o) `shouldBe` ["\NULu\NULp"]
-            (isNothing $ coTLSSettings o) `shouldBe` True
+            (isTrusted $ coTLSSettings o) `shouldBe` False
         
         it "amqp auth host-2 port-2" $ do
             let o = fromURI "amqp://u:p@127.0.0.1:5672,127.0.0.2:5672"
@@ -63,7 +62,7 @@ spec = do
             coVHost o `shouldBe` "/"
             (saslName <$> coAuth o) `shouldBe` ["PLAIN"]
             (saslInitialResponse <$> coAuth o) `shouldBe` ["\NULu\NULp"]
-            (isNothing $ coTLSSettings o) `shouldBe` True
+            (isTrusted $ coTLSSettings o) `shouldBe` False
         
         it "amqp auth host port vhost" $ do
             let o = fromURI "amqp://u:p@127.0.0.1:5672/v"
@@ -71,7 +70,7 @@ spec = do
             coVHost o `shouldBe` "v"
             (saslName <$> coAuth o) `shouldBe` ["PLAIN"]
             (saslInitialResponse <$> coAuth o) `shouldBe` ["\NULu\NULp"]
-            (isNothing $ coTLSSettings o) `shouldBe` True
+            (isTrusted $ coTLSSettings o) `shouldBe` False
         
         it "amqp auth host-2 port-2 vhost" $ do
             let o = fromURI "amqp://u:p@127.0.0.1:5673,127.0.0.2:5674/v"
@@ -79,7 +78,7 @@ spec = do
             coVHost o `shouldBe` "v"
             (saslName <$> coAuth o) `shouldBe` ["PLAIN"]
             (saslInitialResponse <$> coAuth o) `shouldBe` ["\NULu\NULp"]
-            (isNothing $ coTLSSettings o) `shouldBe` True
+            (isTrusted $ coTLSSettings o) `shouldBe` False
         
         it "amqp auth host-3 port-3 vhost" $ do
             let o = fromURI "amqp://a:b@h1:8001,h2:8002,h3:8003/w"
@@ -87,7 +86,7 @@ spec = do
             coVHost o `shouldBe` "w"
             (saslName <$> coAuth o) `shouldBe` ["PLAIN"]
             (saslInitialResponse <$> coAuth o) `shouldBe` ["\NULa\NULb"]
-            (isNothing $ coTLSSettings o) `shouldBe` True
+            (isTrusted $ coTLSSettings o) `shouldBe` False
         
         it "amqp host" $ do
             let o = fromURI "amqp://127.0.0.1"
@@ -97,7 +96,7 @@ spec = do
             (saslName <$> coAuth o) `shouldBe` ["PLAIN"]
             (saslInitialResponse <$> coAuth o) `shouldBe`
                 ["\NUL127.0.0.1\NULguest"]
-            (isNothing $ coTLSSettings o) `shouldBe` True
+            (isTrusted $ coTLSSettings o) `shouldBe` False
         
         it "amqp host-2" $ do
             let o = fromURI "amqp://127.0.0.1,127.0.0.2"
@@ -107,7 +106,7 @@ spec = do
             (saslName <$> coAuth o) `shouldBe` ["PLAIN"]
             (saslInitialResponse <$> coAuth o) `shouldBe`
                 ["\NUL127.0.0.1,127.0.0.2\NULguest"]
-            (isNothing $ coTLSSettings o) `shouldBe` True
+            (isTrusted $ coTLSSettings o) `shouldBe` False
         
         it "amqps auth host" $ do
             let o = fromURI "amqps://u:p@127.0.0.1"
@@ -115,8 +114,7 @@ spec = do
             coVHost o `shouldBe` "/"
             (saslName <$> coAuth o) `shouldBe` ["PLAIN"]
             (saslInitialResponse <$> coAuth o) `shouldBe` ["\NULu\NULp"]
-            -- amqps protocol does not activate TLS!
-            (isNothing $ coTLSSettings o) `shouldBe` True
+            (isTrusted $ coTLSSettings o) `shouldBe` True
         
         it "amqps auth host-2" $ do
             let o = fromURI "amqps://u:p@127.0.0.1,127.0.0.2"
@@ -124,8 +122,7 @@ spec = do
             coVHost o `shouldBe` "/"
             (saslName <$> coAuth o) `shouldBe` ["PLAIN"]
             (saslInitialResponse <$> coAuth o) `shouldBe` ["\NULu\NULp"]
-            -- amqps protocol does not activate TLS!
-            (isNothing $ coTLSSettings o) `shouldBe` True
+            (isTrusted $ coTLSSettings o) `shouldBe` True
         
         it "amqps auth host port" $ do
             let o = fromURI "amqps://u:p@127.0.0.1:5672"
@@ -133,8 +130,7 @@ spec = do
             coVHost o `shouldBe` "/"
             (saslName <$> coAuth o) `shouldBe` ["PLAIN"]
             (saslInitialResponse <$> coAuth o) `shouldBe` ["\NULu\NULp"]
-            -- amqps protocol does not activate TLS!
-            (isNothing $ coTLSSettings o) `shouldBe` True
+            (isTrusted $ coTLSSettings o) `shouldBe` True
         
         it "amqps auth host-2 port" $ do
             let o = fromURI "amqps://u:p@127.0.0.1,127.0.0.1:5673"
@@ -142,8 +138,7 @@ spec = do
             coVHost o `shouldBe` "/"
             (saslName <$> coAuth o) `shouldBe` ["PLAIN"]
             (saslInitialResponse <$> coAuth o) `shouldBe` ["\NULu\NULp"]
-            -- amqps protocol does not activate TLS!
-            (isNothing $ coTLSSettings o) `shouldBe` True
+            (isTrusted $ coTLSSettings o) `shouldBe` True
         
         it "amqps auth host-2 port-2" $ do
             let o = fromURI "amqps://u:p@127.0.0.1:5672,127.0.0.1:5673"
@@ -151,8 +146,7 @@ spec = do
             coVHost o `shouldBe` "/"
             (saslName <$> coAuth o) `shouldBe` ["PLAIN"]
             (saslInitialResponse <$> coAuth o) `shouldBe` ["\NULu\NULp"]
-            -- amqps protocol does not activate TLS!
-            (isNothing $ coTLSSettings o) `shouldBe` True
+            (isTrusted $ coTLSSettings o) `shouldBe` True
         
         it "amqps auth host port vhost" $ do
             let o = fromURI "amqps://u:p@127.0.0.1:5672/v"
@@ -160,8 +154,7 @@ spec = do
             coVHost o `shouldBe` "v"
             (saslName <$> coAuth o) `shouldBe` ["PLAIN"]
             (saslInitialResponse <$> coAuth o) `shouldBe` ["\NULu\NULp"]
-            -- amqps protocol does not activate TLS!
-            (isNothing $ coTLSSettings o) `shouldBe` True
+            (isTrusted $ coTLSSettings o) `shouldBe` True
         
         it "amqps auth host-2 port-2 vhost" $ do
             let o = fromURI "amqps://u:p@127.0.0.1:5672,127.0.0.2:5673/v"
@@ -169,8 +162,7 @@ spec = do
             coVHost o `shouldBe` "v"
             (saslName <$> coAuth o) `shouldBe` ["PLAIN"]
             (saslInitialResponse <$> coAuth o) `shouldBe` ["\NULu\NULp"]
-            -- amqps protocol does not activate TLS!
-            (isNothing $ coTLSSettings o) `shouldBe` True
+            (isTrusted $ coTLSSettings o) `shouldBe` True
         
         it "amqps host" $ do
             let o = fromURI "amqps://127.0.0.1"
@@ -180,8 +172,7 @@ spec = do
             (saslName <$> coAuth o) `shouldBe` ["PLAIN"]
             (saslInitialResponse <$> coAuth o) `shouldBe`
                 ["\NUL127.0.0.1\NULguest"]
-            -- amqps protocol does not activate TLS!
-            (isNothing $ coTLSSettings o) `shouldBe` True
+            (isTrusted $ coTLSSettings o) `shouldBe` True
         
         it "amqps host-2" $ do
             let o = fromURI "amqps://127.0.0.1,127.0.0.2"
@@ -191,5 +182,9 @@ spec = do
             (saslName <$> coAuth o) `shouldBe` ["PLAIN"]
             (saslInitialResponse <$> coAuth o) `shouldBe`
                 ["\NUL127.0.0.1,127.0.0.2\NULguest"]
-            -- amqps protocol does not activate TLS!
-            (isNothing $ coTLSSettings o) `shouldBe` True
+            (isTrusted $ coTLSSettings o) `shouldBe` True
+
+
+isTrusted :: Maybe TLSSettings -> Bool
+isTrusted (Just TLSTrusted) = True
+isTrusted _ = False

--- a/test/Runner.hs
+++ b/test/Runner.hs
@@ -2,6 +2,7 @@ import Test.Hspec
 
 import qualified ConnectionSpec
 import qualified ChannelSpec
+import qualified FromURISpec
 import qualified QueueDeclareSpec
 import qualified QueueDeleteSpec
 import qualified QueuePurgeSpec
@@ -21,6 +22,8 @@ main = hspec $ do
     describe "ExchangeDeclareSpec" ExchangeDeclareSpec.spec
     -- exchange.delete
     describe "ExchangeDeleteSpec"  ExchangeDeleteSpec.spec
+    -- fromuri.*
+    describe "FromURISpec"         FromURISpec.spec
     -- queue.declare
     describe "QueueDeclareSpec"    QueueDeclareSpec.spec
     -- queue.delete


### PR DESCRIPTION
## test: test Network.AMQP.fromURI

Add tests for `fromURI`, which parses URLs into `ConnectionOpts`.

- `SASLMechanism` does not instantiate `Show`, so the test is written such that this is not attempted by HSpec.

- `TLSSettings` does not instantiate `Show`, so the test is written such that this is not attempted by HSpec.

- `amqp://127.0.0.1` appears to break parsing of user and host, with the wrong host selected and the expected host as the user.

- `amqps://` changes default port from `5672` to `5671` as expected, but does not actually activate TLS.

---

## AMQP: rework fromURI to support high-availability multi-broker

Rework `Network.AMQP.fromURI` to support URIs in the form

    amqp://user:pass@host-1:port-2,host-2:port-2/vhost

whilst maintaining backwards-compatibility.

Note that no attempt is made to resolve the issue for URIs of the form

    amqp://127.0.0.1

which appears to be parsed as user rather than a host.

---

## AMQP: change fromURI to activate TLS if amqps

Previously, use of `amqps://` changed default port, but didn't activate TLS. Change `Network.AMQP.fromURI` to activate TLS using `TLSTrusted` if `amqps://` protocol is used. This is likely the assumption anyway, since it was surprising to find that only the port was changed.

This is a breaking change, although I'm unsure whether it should be considered a bugfix or a new feature. Old behaviour is easily retained by changing `amqps://u:p@h` to `amqp://u:p@h:5671`.