### PR TITLE
Example showing exception handling and reconnects

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ build-fast:
 	cabal build $(package) --disable-optimisation --ghc-options "-O0 -j6 +RTS -A128m -n2m -qg -RTS"
 
 build-examples:
-	cabal build amqp-example-confirms amqp-example-consumer amqp-example-producer amqp-example-tls-consumer amqp-example-tls-producer --disable-optimisation --ghc-options "-O0 -j6 +RTS -A128m -n2m -qg -RTS"
+	cabal build amqp-example-confirms amqp-example-consumer amqp-example-producer amqp-example-tls-consumer amqp-example-tls-producer amqp-example-connection-management --disable-optimisation --ghc-options "-O0 -j6 +RTS -A128m -n2m -qg -RTS"
 
 .PHONY : run run-fast build build-fast build-examples
 

--- a/Makefile
+++ b/Makefile
@@ -13,8 +13,47 @@ build:
 build-fast:
 	cabal build $(package) --disable-optimisation --ghc-options "-O0 -j6 +RTS -A128m -n2m -qg -RTS"
 
-build-examples:
-	cabal build amqp-example-confirms amqp-example-consumer amqp-example-producer amqp-example-tls-consumer amqp-example-tls-producer amqp-example-connection-management --disable-optimisation --ghc-options "-O0 -j6 +RTS -A128m -n2m -qg -RTS"
 
-.PHONY : run run-fast build build-fast build-examples
+build-example-confirms:
+	cd examples/confirms && cabal build amqp-example-confirms --disable-optimisation --ghc-options "-O0 -j6 +RTS -A128m -n2m -qg -RTS"
+
+build-example-consumer:
+	cd examples/consumer && cabal build amqp-example-consumer --disable-optimisation --ghc-options "-O0 -j6 +RTS -A128m -n2m -qg -RTS"
+
+build-example-producer:
+	cd examples/producer && cabal build amqp-example-producer --disable-optimisation --ghc-options "-O0 -j6 +RTS -A128m -n2m -qg -RTS"
+
+build-example-tls-consumer:
+	cd examples/tlsConsumer && cabal build amqp-example-tls-consumer --disable-optimisation --ghc-options "-O0 -j6 +RTS -A128m -n2m -qg -RTS"
+
+build-example-tls-producer:
+	cd examples/tlsProducer && cabal build amqp-example-tls-producer --disable-optimisation --ghc-options "-O0 -j6 +RTS -A128m -n2m -qg -RTS"
+
+build-example-connection-management:
+	cd examples/connectionManagement && cabal build amqp-example-connection-management --disable-optimisation --ghc-options "-O0 -j6 +RTS -A128m -n2m -qg -RTS"
+
+build-examples: build-example-confirms build-example-consumer build-example-producer build-example-tls-consumer build-example-tls-producer build-example-connection-management
+
+
+run-example-confirms:
+	cd examples/confirms && cabal run amqp-example-confirms --disable-optimisation --ghc-options "-O0 -j6 +RTS -A128m -n2m -qg -RTS"
+
+run-example-consumer:
+	cd examples/consumer && cabal run amqp-example-consumer --disable-optimisation --ghc-options "-O0 -j6 +RTS -A128m -n2m -qg -RTS"
+
+run-example-producer:
+	cd examples/producer && cabal run amqp-example-producer --disable-optimisation --ghc-options "-O0 -j6 +RTS -A128m -n2m -qg -RTS"
+
+run-example-tls-consumer:
+	cd examples/tlsConsumer && cabal run amqp-example-tls-consumer --disable-optimisation --ghc-options "-O0 -j6 +RTS -A128m -n2m -qg -RTS"
+
+run-example-tls-producer:
+	cd examples/tlsProducer && cabal run amqp-example-tls-producer --disable-optimisation --ghc-options "-O0 -j6 +RTS -A128m -n2m -qg -RTS"
+
+run-example-connection-management:
+	cd examples/connectionManagement && cabal run amqp-example-connection-management --disable-optimisation --ghc-options "-O0 -j6 +RTS -A128m -n2m -qg -RTS"
+
+.PHONY : run run-fast build build-fast build-examples build-example-confirms build-example-consumer build-example-producer build-example-tls-consumer build-example-tls-producer build-example-connection-management
+
+
 

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,20 @@
+package = amqp
+exe = amqp-builder
+
+run:
+	cabal run $(exe)
+
+run-fast:
+	cabal run $(exe) --disable-optimisation --ghc-options "-O0 -j6 +RTS -A128m -n2m -qg -RTS"
+
+build:
+	cabal build $(package) --ghc-options "-j6 +RTS -A128m -n2m -qg -RTS"
+
+build-fast:
+	cabal build $(package) --disable-optimisation --ghc-options "-O0 -j6 +RTS -A128m -n2m -qg -RTS"
+
+build-examples:
+	cabal build amqp-example-confirms amqp-example-consumer amqp-example-producer amqp-example-tls-consumer amqp-example-tls-producer --disable-optimisation --ghc-options "-O0 -j6 +RTS -A128m -n2m -qg -RTS"
+
+.PHONY : run run-fast build build-fast build-examples
+

--- a/amqp.cabal
+++ b/amqp.cabal
@@ -1,5 +1,5 @@
 Name:                amqp
-Version:             0.22.1
+Version:             0.22.2
 Synopsis:            Client library for AMQP servers (currently only RabbitMQ)
 Description:         Client library for AMQP servers (currently only RabbitMQ)
 License:             BSD3
@@ -33,11 +33,10 @@ Library
     stm >= 2.4.0,
     network-uri >= 2.6,
     network > 2.6
-
-
   Exposed-modules:    Network.AMQP, Network.AMQP.Types, Network.AMQP.Lifted
   Other-modules:      Network.AMQP.ChannelAllocator, Network.AMQP.Generated, Network.AMQP.Helpers, Network.AMQP.Protocol, Network.AMQP.Internal, Paths_amqp
   GHC-Options:        -Wall
+
 
 Executable amqp-builder
   default-language: Haskell2010
@@ -45,6 +44,73 @@ Executable amqp-builder
   Hs-Source-Dirs:     Tools
   Main-is:            Builder.hs
   GHC-Options:        -Wall
+
+
+Executable amqp-example-confirms
+  default-language:   Haskell2010
+  Hs-Source-Dirs:     examples/confirms
+  Main-is:            ExampleConfirms.hs
+  GHC-Options:        -Wall
+  Build-Depends:      base >= 4 && < 5
+                    , amqp
+                    , bytestring>=0.9
+                    , stm >= 2.4.0
+                    , time
+                    , containers >= 0.2
+
+
+Executable amqp-example-consumer
+  default-language:   Haskell2010
+  Hs-Source-Dirs:     examples/consumer
+  Main-is:            ExampleConsumer.hs
+  GHC-Options:        -Wall
+  Build-Depends:      base >= 4 && < 5
+                    , amqp
+                    , bytestring>=0.9
+                    , stm >= 2.4.0
+                    , time
+                    , containers >= 0.2
+
+
+Executable amqp-example-producer
+  default-language:   Haskell2010
+  Hs-Source-Dirs:     examples/producer
+  Main-is:            ExampleProducer.hs
+  GHC-Options:        -Wall
+  Build-Depends:      base >= 4 && < 5
+                    , amqp
+                    , bytestring>=0.9
+                    , stm >= 2.4.0
+                    , time
+                    , containers >= 0.2
+
+
+Executable amqp-example-tls-consumer
+  default-language:   Haskell2010
+  Hs-Source-Dirs:     examples/tlsConsumer
+  Main-is:            ExampleTLSConsumer.hs
+  GHC-Options:        -Wall
+  Build-Depends:      base >= 4 && < 5
+                    , amqp
+                    , bytestring>=0.9
+                    , stm >= 2.4.0
+                    , time
+                    , containers >= 0.2
+
+
+Executable amqp-example-tls-producer
+  default-language:   Haskell2010
+  Hs-Source-Dirs:     examples/tlsProducer
+  Main-is:            ExampleTLSProducer.hs
+  GHC-Options:        -Wall
+  Build-Depends:      base >= 4 && < 5
+                    , amqp
+                    , bytestring>=0.9
+                    , stm >= 2.4.0
+                    , time
+                    , containers >= 0.2
+
+
 
 source-repository head
   type:     git

--- a/amqp.cabal
+++ b/amqp.cabal
@@ -111,6 +111,24 @@ Executable amqp-example-tls-producer
                     , containers >= 0.2
 
 
+Executable amqp-example-connection-management
+  default-language:   Haskell2010
+  Hs-Source-Dirs:     examples/connectionManagement
+  Main-is:            ExampleConnectionManagement.hs
+  other-modules:      ConnectionManager
+  GHC-Options:        -Wall
+  Build-Depends:      base >= 4 && < 5
+                    , amqp
+                    , bytestring>=0.9
+                    , containers >= 0.2
+                    , resource-pool
+                    , safe
+                    , safe-exceptions
+                    , stm >= 2.4.0
+                    , text
+                    , time
+
+
 
 source-repository head
   type:     git

--- a/amqp.cabal
+++ b/amqp.cabal
@@ -12,9 +12,7 @@ Build-Type:          Simple
 Homepage:            https://github.com/hreinhardt/amqp
 bug-reports:         https://github.com/hreinhardt/amqp/issues
 Cabal-Version:       >=1.10
-Extra-source-files:  examples/ExampleConsumer.hs,
-                     examples/ExampleProducer.hs,
-                     changelog.md
+Extra-source-files:  changelog.md
 
 Library
   default-language: Haskell2010
@@ -44,90 +42,6 @@ Executable amqp-builder
   Hs-Source-Dirs:     Tools
   Main-is:            Builder.hs
   GHC-Options:        -Wall
-
-
-Executable amqp-example-confirms
-  default-language:   Haskell2010
-  Hs-Source-Dirs:     examples/confirms
-  Main-is:            ExampleConfirms.hs
-  GHC-Options:        -Wall
-  Build-Depends:      base >= 4 && < 5
-                    , amqp
-                    , bytestring>=0.9
-                    , stm >= 2.4.0
-                    , time
-                    , containers >= 0.2
-
-
-Executable amqp-example-consumer
-  default-language:   Haskell2010
-  Hs-Source-Dirs:     examples/consumer
-  Main-is:            ExampleConsumer.hs
-  GHC-Options:        -Wall
-  Build-Depends:      base >= 4 && < 5
-                    , amqp
-                    , bytestring>=0.9
-                    , stm >= 2.4.0
-                    , time
-                    , containers >= 0.2
-
-
-Executable amqp-example-producer
-  default-language:   Haskell2010
-  Hs-Source-Dirs:     examples/producer
-  Main-is:            ExampleProducer.hs
-  GHC-Options:        -Wall
-  Build-Depends:      base >= 4 && < 5
-                    , amqp
-                    , bytestring>=0.9
-                    , stm >= 2.4.0
-                    , time
-                    , containers >= 0.2
-
-
-Executable amqp-example-tls-consumer
-  default-language:   Haskell2010
-  Hs-Source-Dirs:     examples/tlsConsumer
-  Main-is:            ExampleTLSConsumer.hs
-  GHC-Options:        -Wall
-  Build-Depends:      base >= 4 && < 5
-                    , amqp
-                    , bytestring>=0.9
-                    , stm >= 2.4.0
-                    , time
-                    , containers >= 0.2
-
-
-Executable amqp-example-tls-producer
-  default-language:   Haskell2010
-  Hs-Source-Dirs:     examples/tlsProducer
-  Main-is:            ExampleTLSProducer.hs
-  GHC-Options:        -Wall
-  Build-Depends:      base >= 4 && < 5
-                    , amqp
-                    , bytestring>=0.9
-                    , stm >= 2.4.0
-                    , time
-                    , containers >= 0.2
-
-
-Executable amqp-example-connection-management
-  default-language:   Haskell2010
-  Hs-Source-Dirs:     examples/connectionManagement
-  Main-is:            ExampleConnectionManagement.hs
-  other-modules:      ConnectionManager
-  GHC-Options:        -Wall
-  Build-Depends:      base >= 4 && < 5
-                    , amqp
-                    , bytestring>=0.9
-                    , containers >= 0.2
-                    , resource-pool
-                    , safe
-                    , safe-exceptions
-                    , stm >= 2.4.0
-                    , text
-                    , time
-
 
 
 source-repository head

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,7 @@
+### Version 0.22.2
+
+* connection management example added
+
 ### Version 0.22.1
 
 * fix a potential deadlock in `closeConnection`

--- a/examples/confirms/confirms.cabal
+++ b/examples/confirms/confirms.cabal
@@ -1,17 +1,7 @@
 Name:                confirms
-Version:             0.22.2
-Synopsis:            Client library for AMQP servers (currently only RabbitMQ)
-Description:         Client library for AMQP servers (currently only RabbitMQ)
-License:             BSD3
-Stability:           alpha
-License-file:        LICENSE
-Author:              Holger Reinhardt
-Category:            Network
-Maintainer:          Holger Reinhardt <hreinhardt@gmail.com>
-Build-Type:          Simple
-Homepage:            https://github.com/hreinhardt/amqp
-bug-reports:         https://github.com/hreinhardt/amqp/issues
+Version:             1
 Cabal-Version:       >=1.10
+Build-Type:          Simple
 
 Executable amqp-example-confirms
   default-language:   Haskell2010
@@ -24,9 +14,3 @@ Executable amqp-example-confirms
                     , stm >= 2.4.0
                     , time
                     , containers >= 0.2
-
-
-
-source-repository head
-  type:     git
-  location: https://github.com/hreinhardt/amqp

--- a/examples/confirms/confirms.cabal
+++ b/examples/confirms/confirms.cabal
@@ -1,0 +1,32 @@
+Name:                confirms
+Version:             0.22.2
+Synopsis:            Client library for AMQP servers (currently only RabbitMQ)
+Description:         Client library for AMQP servers (currently only RabbitMQ)
+License:             BSD3
+Stability:           alpha
+License-file:        LICENSE
+Author:              Holger Reinhardt
+Category:            Network
+Maintainer:          Holger Reinhardt <hreinhardt@gmail.com>
+Build-Type:          Simple
+Homepage:            https://github.com/hreinhardt/amqp
+bug-reports:         https://github.com/hreinhardt/amqp/issues
+Cabal-Version:       >=1.10
+
+Executable amqp-example-confirms
+  default-language:   Haskell2010
+  Hs-Source-Dirs:     .
+  Main-is:            ExampleConfirms.hs
+  GHC-Options:        -Wall
+  Build-Depends:      base >= 4 && < 5
+                    , amqp >= 0.22.1
+                    , bytestring>=0.9
+                    , stm >= 2.4.0
+                    , time
+                    , containers >= 0.2
+
+
+
+source-repository head
+  type:     git
+  location: https://github.com/hreinhardt/amqp

--- a/examples/connectionManagement/ConnectionManager.hs
+++ b/examples/connectionManagement/ConnectionManager.hs
@@ -1,3 +1,34 @@
+{-|
+Module      : ConnectionManager
+Description : Demo showing how AMQP connections and channels can be managed to deal with exceptions
+
+This module should demonstrate how to
+  - Handle an initial connection if the AMQP server is stopped or unreachable
+  - Handle an AMQP server being stopped or unreachable while executing
+  - Manage a pool of channels (using Data.Pool) so that you are not creating channels too often
+     see https://www.rabbitmq.com/production-checklist.html#apps-connection-churn
+  - Manage a single shared connection
+     see https://www.rabbitmq.com/production-checklist.html#apps-connection-management
+  - Automatically restart consumers (`consumeMsgs`) when the connection is restarted
+     see `addOnReconnect` and its use in the Main.hs demo
+
+
+Some notes on usage
+  - Use Network.AMQP version 0.22.1 or above as it contains a fix for a potential connection issue
+     https://github.com/hreinhardt/amqp/commit/ff169bbb8eec2d62efb4819f56f2c2d679ff4fc5
+     In general always use the latest version possible
+  - There are various settings in `Opts` that you can configure.
+     E.g. Changing the pool size and how long to keep a channel open
+  - Control.Exception.Safe is used to avoid catching exceptions that should not be handled by user code
+     See https://hackage.haskell.org/package/safe-exceptions
+  - Read the Hackage docs esp the section on "Exceptions in the callback".
+  - Data.Pool does most of the heavy lifting for managing the channels
+
+
+Please note that this is an example and should not be considered production ready as-is.
+This code has not undergone the same testing as the core modules.
+-}
+
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE NumericUnderscores #-}
 {-# LANGUAGE OverloadedStrings #-}
@@ -11,7 +42,6 @@ module ConnectionManager
     , closeHandle
     , defaultOpts
     , mkHandle
-    , retryUntilConnectionClose
     , withChannel
     , withConnection
     ) where
@@ -29,31 +59,36 @@ import Data.Time (NominalDiffTime)
 import           Safe (atMay, lastMay)
 
 
+-- | Connection options
 data Opts = Opts
-  { opKeepChannelOpenSeconds :: !NominalDiffTime
-  , opMaxPooledChannels :: !Int
-  , opRetyConnectionBackoffMilliseconds :: ![Int]
-  , opRetyConnectionMaxAttempts :: !(Maybe Int)
-  , opChanCreateFn :: !(Maybe (Rb.Channel -> IO ()))
+  { opKeepChannelOpenSeconds :: !NominalDiffTime     -- ^ Amount of time for which an unused resource is kept open. The smallest acceptable value is 0.5
+  , opMaxPooledChannels :: !Int                      -- ^ Maximum number of channels to keep open. The smallest acceptable value is 1.
+  , opRetyConnectionBackoffMilliseconds :: ![Int]    -- ^ milliseconds to delay between connection attempts
+  , opRetyConnectionMaxAttempts :: !(Maybe Int)      -- ^ How many times to retry connection. Nothing = never
+  , opChanCreateFn :: !(Maybe (Rb.Channel -> IO ())) -- ^ Function to run on each new connection, e.g. setting qos
   }
 
 
 defaultOpts :: Opts
 defaultOpts =
   Opts
-    { opKeepChannelOpenSeconds = 60 -- ^ Amount of time for which an unused resource is kept open. The smallest acceptable value is 0.5
-    , opMaxPooledChannels = 5 -- ^ Maximum number of channels to keep open. The smallest acceptable value is 1.
-    , opRetyConnectionBackoffMilliseconds = [100, 250, 475, 813, 1_319, 2_078, 3_217, 4_926] -- ^ milliseconds to delay between connection attempts
-    , opRetyConnectionMaxAttempts = Just 200 -- ^ How many times to retry connection. Nothing = never
-    , opChanCreateFn = Nothing -- ^ Function to run on each new connection, e.g. setting qos
+    { opKeepChannelOpenSeconds = 60
+    , opMaxPooledChannels = 5
+    , opRetyConnectionBackoffMilliseconds = [100, 250, 475, 813, 1_319, 2_078, 3_217, 4_926]
+    , opRetyConnectionMaxAttempts = Just 200
+    , opChanCreateFn = Nothing
     }
 
 
 
--- Combined connection and pool, makes it easier to ensure the pool is not used while the connection is being recreated etc
+-- Combined connection and pool
+-- This makes it easier to ensure the pool is not used while the connection is being recreated etc
+-- i.e. a pool is associated with a single open connection
 newtype Mcp = Mcp (Mv.MVar (Rb.Connection, Pl.Pool Rb.Channel))
 
--- | Opaque handle representing a rabbit connection
+
+-- | Opaque handle representing a AMQP connection
+-- This is the type that the user will use rather than the normal Network.AMQP.Connection
 data Handle = Handle
   { hMcp :: !Mcp -- ^ Connection and it's pool of channels
   , hWithConnection :: !(forall a. Handle -> (Rb.Connection -> IO a) -> IO a) -- ^ Helper method for the public withConnection function
@@ -82,7 +117,9 @@ mkHandle ropts copts = do
     initMcp :: Handle -> IO Handle
     initMcp h = do
       let (Mcp mcp) = hMcp h
+      -- Create a new channel pool for the new connection
       pool <- Pl.createPool (createChan h) Rb.closeChannel 1 (opKeepChannelOpenSeconds copts) (opMaxPooledChannels copts)
+      -- Create a new connection
       conn <- newRabbitConnection h
       Mv.putMVar mcp (conn, pool)
       pure h
@@ -92,13 +129,18 @@ mkHandle ropts copts = do
     createChan h = do
       let (Mcp mcp) = hMcp h
       (c, _) <- Mv.readMVar mcp
+      -- Create a new channel
+      -- Optionally call opChanCreateFn if it is not Nothing
+      -- Call addChannelExceptionHandler so we can manage any channel exceptions
       manageRabbitException
         h
         (do
           ch <- Rb.openChannel c
+
           case opChanCreateFn copts of
             Nothing -> pure ()
             Just f -> f ch
+
           Rb.addChannelExceptionHandler ch (onRabbitException h)
           pure ch
         )
@@ -106,10 +148,14 @@ mkHandle ropts copts = do
 
     onRabbitException :: Handle -> SomeException -> IO a
     onRabbitException h ex =
+      -- Use `isNormalChannelClose` to see if the channel was closed normally or if there was an error
+      -- See the docs for `isNormalChannelClose` for details
       if Rb.isNormalChannelClose ex
         then
+          -- Normal close, so rethrow so that the normal shutdown can occur
           throwM ex
         else do
+          -- Unexpected exception. Assume that the connection will is terminated and start a new one.
           restartConnection h
           throwM ex
 
@@ -117,8 +163,13 @@ mkHandle ropts copts = do
     restartConnection h = do
       let (Mcp mcp) = hMcp h
       (_conn, pool) <- Mv.takeMVar mcp
+
+      -- Try to close any open channels from the old pool
       Pl.destroyAllResources pool
+      -- New connection and pool
       _ <- initMcp h
+
+      -- Run all the actions that the user wanted to happen after a reconnect
       rs <- Tv.readTVarIO $ hOnReconnect h
       sequenceA_ rs
 
@@ -131,12 +182,17 @@ mkHandle ropts copts = do
     withConnection' :: Handle -> (Rb.Connection -> IO a) -> IO a
     withConnection' h@(Handle (Mcp cp') _ _) fn = do
       (conn, _pool) <- Mv.readMVar cp'
+      -- Run the user function with a connection
+      -- Any exception in the user function is assumed to be problem with the connection
+      -- The user should only run functions that actually need the connection in the callback
       manageRabbitException h (fn conn)
 
 
     newRabbitConnection :: Handle -> IO Rb.Connection
     newRabbitConnection h = do
+      -- Get a new connection, possibly waiting for the server
       conn <- tryNewRabbitConnection (fromMaybe 0 $ opRetyConnectionMaxAttempts copts) 0
+      -- Add a handler to watch for connection closes
       Rb.addConnectionClosedHandler conn True (restartConnection h)
       pure conn
 
@@ -151,16 +207,21 @@ mkHandle ropts copts = do
             then throwM ex
           else do
             let
+              -- Get the back off values
               backoff = opRetyConnectionBackoffMilliseconds copts
               -- Largest possible back off, default of 200ms if none was set
               largestBackoffMs = fromMaybe 200 . lastMay $ backoff
               -- Delay for current number of retries
               delay = 1_000 * fromMaybe largestBackoffMs (atMay backoff atRetry)
 
+            -- Delay
             threadDelay delay
+            -- Try again
             tryNewRabbitConnection (retriesLeft - 1) (atRetry + 1)
          )
 
+
+-- | Close the handle's connection and channels
 closeHandle :: Handle -> IO ()
 closeHandle (Handle (Mcp mcp) _ _) =
   Mv.tryTakeMVar mcp >>= \case
@@ -168,26 +229,20 @@ closeHandle (Handle (Mcp mcp) _ _) =
     Just (conn, _) -> Rb.closeConnection conn
 
 
+-- | Perform an operation with a pooled channel. Keep this callback as small as possible, only functions that actually need a channel
 withChannel :: Handle -> (Rb.Channel -> IO a) -> IO a
 withChannel (Handle (Mcp mcp) _ _) fn = do
   (_, pool) <- Mv.readMVar mcp
   Pl.withResource pool fn
 
 
+-- | Perform an operation with the connection. Keep this callback as small as possible, only functions that actually need the connection
 withConnection :: Handle -> (Rb.Connection -> IO a) -> IO a
 withConnection h@(Handle _ w _) = w h
 
 
-retryUntilConnectionClose :: Int -> IO a -> IO a
-retryUntilConnectionClose retrySecs fn =
-  catch fn handleEx
-
-  where
-    handleEx (_::SomeException) = do
-      threadDelay retrySecs
-      retryUntilConnectionClose retrySecs fn
-
-
+-- | Add a callback to run when the connection is reconnected
+-- Note this does not run the callback immediately only on reconnect
 addOnReconnect :: Handle -> IO () -> IO ()
 addOnReconnect (Handle _ _ rs') fn =
   atomically . Tv.modifyTVar' rs' $ \rs -> fn : rs

--- a/examples/connectionManagement/ConnectionManager.hs
+++ b/examples/connectionManagement/ConnectionManager.hs
@@ -1,0 +1,193 @@
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE NumericUnderscores #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+module ConnectionManager
+    ( Handle
+    , Opts(..)
+    , addOnReconnect
+    , closeHandle
+    , defaultOpts
+    , mkHandle
+    , retryUntilConnectionClose
+    , withChannel
+    , withConnection
+    ) where
+
+import qualified Control.Concurrent.MVar as Mv
+import           Control.Concurrent.STM (atomically)
+import qualified Control.Concurrent.STM.TVar as Tv
+import           Control.Concurrent (threadDelay)
+import           Control.Exception.Safe (catch, throwM, SomeException)
+import           Data.Foldable (sequenceA_)
+import           Data.Maybe (fromMaybe)
+import qualified Data.Pool as Pl
+import qualified Network.AMQP as Rb
+import Data.Time (NominalDiffTime)
+import           Safe (atMay, lastMay)
+
+
+data Opts = Opts
+  { opKeepChannelOpenSeconds :: !NominalDiffTime
+  , opMaxPooledChannels :: !Int
+  , opRetyConnectionBackoffMilliseconds :: ![Int]
+  , opRetyConnectionMaxAttempts :: !(Maybe Int)
+  , opChanCreateFn :: !(Maybe (Rb.Channel -> IO ()))
+  }
+
+
+defaultOpts :: Opts
+defaultOpts =
+  Opts
+    { opKeepChannelOpenSeconds = 60 -- ^ Amount of time for which an unused resource is kept open. The smallest acceptable value is 0.5
+    , opMaxPooledChannels = 5 -- ^ Maximum number of channels to keep open. The smallest acceptable value is 1.
+    , opRetyConnectionBackoffMilliseconds = [100, 250, 475, 813, 1_319, 2_078, 3_217, 4_926] -- ^ milliseconds to delay between connection attempts
+    , opRetyConnectionMaxAttempts = Just 200 -- ^ How many times to retry connection. Nothing = never
+    , opChanCreateFn = Nothing -- ^ Function to run on each new connection, e.g. setting qos
+    }
+
+
+
+-- Combined connection and pool, makes it easier to ensure the pool is not used while the connection is being recreated etc
+newtype Mcp = Mcp (Mv.MVar (Rb.Connection, Pl.Pool Rb.Channel))
+
+-- | Opaque handle representing a rabbit connection
+data Handle = Handle
+  { hMcp :: !Mcp -- ^ Connection and it's pool of channels
+  , hWithConnection :: !(forall a. Handle -> (Rb.Connection -> IO a) -> IO a) -- ^ Helper method for the public withConnection function
+  , hOnReconnect :: !(Tv.TVar [IO ()]) -- ^ Actions to perform when reconnecting to rabbit
+  }
+
+
+-- | Create a new handle to manage a rabbit connection
+mkHandle
+  :: Rb.ConnectionOpts -- ^ Connection options
+  -> Opts -- ^ Connection management options
+  -> IO Handle
+mkHandle ropts copts = do
+  mcp <- Mv.newEmptyMVar
+  rs <- Tv.newTVarIO []
+
+  initMcp Handle
+            { hMcp = Mcp mcp
+            , hWithConnection = withConnection'
+            , hOnReconnect = rs
+            }
+
+
+  where
+    -- | Create a connection and it's associated pool of channels
+    initMcp :: Handle -> IO Handle
+    initMcp h = do
+      let (Mcp mcp) = hMcp h
+      pool <- Pl.createPool (createChan h) Rb.closeChannel 1 (opKeepChannelOpenSeconds copts) (opMaxPooledChannels copts)
+      conn <- newRabbitConnection h
+      Mv.putMVar mcp (conn, pool)
+      pure h
+
+
+    createChan :: Handle -> IO Rb.Channel
+    createChan h = do
+      let (Mcp mcp) = hMcp h
+      (c, _) <- Mv.readMVar mcp
+      manageRabbitException
+        h
+        (do
+          ch <- Rb.openChannel c
+          case opChanCreateFn copts of
+            Nothing -> pure ()
+            Just f -> f ch
+          Rb.addChannelExceptionHandler ch (onRabbitException h)
+          pure ch
+        )
+
+
+    onRabbitException :: Handle -> SomeException -> IO a
+    onRabbitException h ex =
+      if Rb.isNormalChannelClose ex
+        then
+          throwM ex
+        else do
+          restartConnection h
+          throwM ex
+
+    restartConnection :: Handle -> IO ()
+    restartConnection h = do
+      let (Mcp mcp) = hMcp h
+      (_conn, pool) <- Mv.takeMVar mcp
+      Pl.destroyAllResources pool
+      _ <- initMcp h
+      rs <- Tv.readTVarIO $ hOnReconnect h
+      sequenceA_ rs
+
+
+    manageRabbitException :: Handle -> IO a -> IO a
+    manageRabbitException h fn =
+      catch fn (onRabbitException h)
+
+
+    withConnection' :: Handle -> (Rb.Connection -> IO a) -> IO a
+    withConnection' h@(Handle (Mcp cp') _ _) fn = do
+      (conn, _pool) <- Mv.readMVar cp'
+      manageRabbitException h (fn conn)
+
+
+    newRabbitConnection :: Handle -> IO Rb.Connection
+    newRabbitConnection h = do
+      conn <- tryNewRabbitConnection (fromMaybe 0 $ opRetyConnectionMaxAttempts copts) 0
+      Rb.addConnectionClosedHandler conn True (restartConnection h)
+      pure conn
+
+
+    tryNewRabbitConnection :: Int -> Int -> IO Rb.Connection
+    tryNewRabbitConnection retriesLeft atRetry = do
+      -- Loop until connected
+      catch
+        (Rb.openConnection'' ropts)
+        (\(ex::SomeException) ->
+          if retriesLeft <= 0
+            then throwM ex
+          else do
+            let
+              backoff = opRetyConnectionBackoffMilliseconds copts
+              -- Largest possible back off, default of 200ms if none was set
+              largestBackoffMs = fromMaybe 200 . lastMay $ backoff
+              -- Delay for current number of retries
+              delay = 1_000 * fromMaybe largestBackoffMs (atMay backoff atRetry)
+
+            threadDelay delay
+            tryNewRabbitConnection (retriesLeft - 1) (atRetry + 1)
+         )
+
+closeHandle :: Handle -> IO ()
+closeHandle (Handle (Mcp mcp) _ _) =
+  Mv.tryTakeMVar mcp >>= \case
+    Nothing -> pure ()
+    Just (conn, _) -> Rb.closeConnection conn
+
+
+withChannel :: Handle -> (Rb.Channel -> IO a) -> IO a
+withChannel (Handle (Mcp mcp) _ _) fn = do
+  (_, pool) <- Mv.readMVar mcp
+  Pl.withResource pool fn
+
+
+withConnection :: Handle -> (Rb.Connection -> IO a) -> IO a
+withConnection h@(Handle _ w _) = w h
+
+
+retryUntilConnectionClose :: Int -> IO a -> IO a
+retryUntilConnectionClose retrySecs fn =
+  catch fn handleEx
+
+  where
+    handleEx (_::SomeException) = do
+      threadDelay retrySecs
+      retryUntilConnectionClose retrySecs fn
+
+
+addOnReconnect :: Handle -> IO () -> IO ()
+addOnReconnect (Handle _ _ rs') fn =
+  atomically . Tv.modifyTVar' rs' $ \rs -> fn : rs

--- a/examples/connectionManagement/ExampleConnectionManagement.hs
+++ b/examples/connectionManagement/ExampleConnectionManagement.hs
@@ -44,6 +44,7 @@ import           Network.AMQP ( Ack(..)
 import qualified ConnectionManager as Cm
 
 -- | Example showing the use of ConnectionManager to manage connection and channel failure
+-- You can run this example by running `make run-example-connection-management`
 main :: IO ()
 main = do
   -- Use `mkHandle` rather than `openConnection`

--- a/examples/connectionManagement/ExampleConnectionManagement.hs
+++ b/examples/connectionManagement/ExampleConnectionManagement.hs
@@ -1,3 +1,15 @@
+{-|
+Module      : Main
+Description : Example showing error handling
+
+This example uses the demo ConnectionManager module to handle connection and channel errors.
+You should be able to start this demo (`cabal run amqp-example-connection-management`) before
+RabbitMQ is running, terminate RabbitMQ while it is running etc and it should continue to
+work.
+
+See the ConnectionManager module for an explanation of the implementation.
+-}
+
 {-# LANGUAGE NumericUnderscores #-}
 {-# LANGUAGE OverloadedStrings #-}
 
@@ -7,7 +19,7 @@ module Main
 
 import qualified Data.ByteString.Lazy.Char8 as BL
 import           Control.Concurrent (threadDelay)
-import           Control.Monad (void, (>=>))
+import           Control.Monad (void)
 import qualified Data.Time as Dt
 import           Network.AMQP ( Ack(..)
                               , DeliveryMode(..)
@@ -31,41 +43,88 @@ import           Network.AMQP ( Ack(..)
 
 import qualified ConnectionManager as Cm
 
-
+-- | Example showing the use of ConnectionManager to manage connection and channel failure
 main :: IO ()
 main = do
+  -- Use `mkHandle` rather than `openConnection`
+  -- This will create a "handle" that you can use to safely get the connection and a channel
   cm <- Cm.mkHandle (fromURI "amqp://guest:guest@localhost:5672") Cm.defaultOpts
 
-  Cm.withConnection cm $ getServerProperties >=> print
+  -- Example of using the connection to get the server properties
+  Cm.withConnection cm $ \conn -> do
+    props <- getServerProperties conn
+    print props
 
+
+  -----------------------------------------------------------------------------------------------------------
+  -- Setup --
+  --
+  -- Setup for the consumer and producer
+  -- Using `withChannel` to get a channel from the pool.
+  --
+  -- This is otherwise very similar to ExampleConsumer/ExampleProducer
+  -- NB do as little work in withChannel as possible. You want to use the channel
+  -- and return it to the pool so that it can be used elsewhere.
+  -----------------------------------------------------------------------------------------------------------
   Cm.withChannel cm $ \chan -> do
     void $ declareQueue chan newQueue {queueName = "myQueueEN"}
     declareExchange chan newExchange {exchangeName = "topicExchg", exchangeType = "topic"}
     bindQueue chan "myQueueEN" "topicExchg" "en.*"
+  -----------------------------------------------------------------------------------------------------------
 
+
+  -----------------------------------------------------------------------------------------------------------
+  -- Consumer --
+  --
+  -- If the connection is killed then any handler started by `consumeMsgs` will no longer be running.
+  --
+  -- The ConnectionManager has an `addOnReconnect` function that lets you run your code when a
+  -- reconnect succeeds.
+  -----------------------------------------------------------------------------------------------------------
   let runConsumer =
+        -- The call to `consumeMsgs` that we want to keep running
         Cm.withChannel cm $ \chan -> do
          void $ consumeMsgs chan "myQueueEN" Ack myCallbackEN
 
 
+  -- Start automatically of the connection is stopped
   Cm.addOnReconnect cm runConsumer
+  -- And start the consumer right now as well
   runConsumer
+  -----------------------------------------------------------------------------------------------------------
 
+
+  -----------------------------------------------------------------------------------------------------------
+  -- Producer
+  --
+  -- Run the producer demo loop
+  -----------------------------------------------------------------------------------------------------------
   runProducer cm 0
+  -----------------------------------------------------------------------------------------------------------
+
+
+  -- This will never get called in this demo
   Cm.closeHandle cm
 
 
 
+-- | Callback for the consumer
 myCallbackEN :: (Message, Envelope) -> IO ()
 myCallbackEN (msg, env) = do
   putStrLn $ "received from EN: " <> BL.unpack (msgBody msg)
   ackEnv env
 
 
+
+-- | Producer loop
+--
+-- This loop will try to publish a message once a second
 runProducer :: Cm.Handle -> Int -> IO ()
 runProducer cm count = do
   dt <- Dt.getCurrentTime
+
   -- Do as little work in withChannel or withConnection as possible
+  -- Notice that `getCurrentTime` and esp the threadDelay are called before/after withChannel
   Cm.withChannel cm $ \chan ->
     void $ publishMsg
              chan
@@ -76,7 +135,7 @@ runProducer cm count = do
                       }
               )
 
-  -- NB don't block in the withChannel
+  -- NB don't block in the withChannel call
   threadDelay 1_000_000
   runProducer cm (count + 1)
 

--- a/examples/connectionManagement/ExampleConnectionManagement.hs
+++ b/examples/connectionManagement/ExampleConnectionManagement.hs
@@ -1,0 +1,82 @@
+{-# LANGUAGE NumericUnderscores #-}
+{-# LANGUAGE OverloadedStrings #-}
+
+module Main
+    ( main
+    ) where
+
+import qualified Data.ByteString.Lazy.Char8 as BL
+import           Control.Concurrent (threadDelay)
+import           Control.Monad (void, (>=>))
+import qualified Data.Time as Dt
+import           Network.AMQP ( Ack(..)
+                              , DeliveryMode(..)
+                              , Envelope(..)
+                              , Message(..)
+                              , ackEnv
+                              , bindQueue
+                              , consumeMsgs
+                              , declareExchange
+                              , declareQueue
+                              , exchangeName
+                              , exchangeType
+                              , fromURI
+                              , getServerProperties
+                              , newExchange
+                              , newMsg
+                              , publishMsg
+                              , newQueue
+                              , queueName
+                              )
+
+import qualified ConnectionManager as Cm
+
+
+main :: IO ()
+main = do
+  cm <- Cm.mkHandle (fromURI "amqp://guest:guest@localhost:5672") Cm.defaultOpts
+
+  Cm.withConnection cm $ getServerProperties >=> print
+
+  Cm.withChannel cm $ \chan -> do
+    void $ declareQueue chan newQueue {queueName = "myQueueEN"}
+    declareExchange chan newExchange {exchangeName = "topicExchg", exchangeType = "topic"}
+    bindQueue chan "myQueueEN" "topicExchg" "en.*"
+
+  let runConsumer =
+        Cm.withChannel cm $ \chan -> do
+         void $ consumeMsgs chan "myQueueEN" Ack myCallbackEN
+
+
+  Cm.addOnReconnect cm runConsumer
+  runConsumer
+
+  runProducer cm 0
+  Cm.closeHandle cm
+
+
+
+myCallbackEN :: (Message, Envelope) -> IO ()
+myCallbackEN (msg, env) = do
+  putStrLn $ "received from EN: " <> BL.unpack (msgBody msg)
+  ackEnv env
+
+
+runProducer :: Cm.Handle -> Int -> IO ()
+runProducer cm count = do
+  dt <- Dt.getCurrentTime
+  -- Do as little work in withChannel or withConnection as possible
+  Cm.withChannel cm $ \chan ->
+    void $ publishMsg
+             chan
+             "topicExchg"
+             "en.hello"
+              (newMsg { msgBody = BL.pack (show dt <> " #" <> show count)
+                      , msgDeliveryMode = Just NonPersistent
+                      }
+              )
+
+  -- NB don't block in the withChannel
+  threadDelay 1_000_000
+  runProducer cm (count + 1)
+

--- a/examples/connectionManagement/connectionManagement.cabal
+++ b/examples/connectionManagement/connectionManagement.cabal
@@ -1,0 +1,37 @@
+Name:                connectionManagement
+Version:             0.22.2
+Synopsis:            Client library for AMQP servers (currently only RabbitMQ)
+Description:         Client library for AMQP servers (currently only RabbitMQ)
+License:             BSD3
+Stability:           alpha
+License-file:        LICENSE
+Author:              Holger Reinhardt
+Category:            Network
+Maintainer:          Holger Reinhardt <hreinhardt@gmail.com>
+Build-Type:          Simple
+Homepage:            https://github.com/hreinhardt/amqp
+bug-reports:         https://github.com/hreinhardt/amqp/issues
+Cabal-Version:       >=1.10
+
+Executable amqp-example-connection-management
+  default-language:   Haskell2010
+  Hs-Source-Dirs:     .
+  Main-is:            ExampleConnectionManagement.hs
+  other-modules:      ConnectionManager
+  GHC-Options:        -Wall
+  Build-Depends:      base >= 4 && < 5
+                    , amqp >= 0.22.1
+                    , bytestring>=0.9
+                    , containers >= 0.2
+                    , resource-pool
+                    , safe
+                    , safe-exceptions
+                    , stm >= 2.4.0
+                    , text
+                    , time
+
+
+
+source-repository head
+  type:     git
+  location: https://github.com/hreinhardt/amqp

--- a/examples/connectionManagement/connectionManagement.cabal
+++ b/examples/connectionManagement/connectionManagement.cabal
@@ -1,17 +1,7 @@
 Name:                connectionManagement
-Version:             0.22.2
-Synopsis:            Client library for AMQP servers (currently only RabbitMQ)
-Description:         Client library for AMQP servers (currently only RabbitMQ)
-License:             BSD3
-Stability:           alpha
-License-file:        LICENSE
-Author:              Holger Reinhardt
-Category:            Network
-Maintainer:          Holger Reinhardt <hreinhardt@gmail.com>
-Build-Type:          Simple
-Homepage:            https://github.com/hreinhardt/amqp
-bug-reports:         https://github.com/hreinhardt/amqp/issues
+Version:             1
 Cabal-Version:       >=1.10
+Build-Type:          Simple
 
 Executable amqp-example-connection-management
   default-language:   Haskell2010
@@ -29,9 +19,3 @@ Executable amqp-example-connection-management
                     , stm >= 2.4.0
                     , text
                     , time
-
-
-
-source-repository head
-  type:     git
-  location: https://github.com/hreinhardt/amqp

--- a/examples/consumer/ExampleConsumer.hs
+++ b/examples/consumer/ExampleConsumer.hs
@@ -1,40 +1,37 @@
-{-# OPTIONS -XOverloadedStrings #-}
-module ExampleTLSConsumer where
+{-# LANGUAGE OverloadedStrings #-}
+module Main where
 
 import Network.AMQP
 
 import qualified Data.ByteString.Lazy.Char8 as BL
 
 
+main :: IO ()
 main = do
-    let opts = defaultConnectionOpts {
-            coServers = [("127.0.0.1", 5671)]
-          , coTLSSettings = Just TLSTrusted
-          }
-    conn <- openConnection'' opts
+    conn <- openConnection "127.0.0.1" "/" "guest" "guest"
     chan <- openChannel conn
 
-
+    
     --declare queues, exchanges and bindings
-    declareQueue chan newQueue {queueName = "myQueueDE"}
-    declareQueue chan newQueue {queueName = "myQueueEN"}
+    _ <- declareQueue chan newQueue {queueName = "myQueueDE"}
+    _ <- declareQueue chan newQueue {queueName = "myQueueEN"}
 
     declareExchange chan newExchange {exchangeName = "topicExchg", exchangeType = "topic"}
     bindQueue chan "myQueueDE" "topicExchg" "de.*"
     bindQueue chan "myQueueEN" "topicExchg" "en.*"
-
+    
 
     --subscribe to the queues
-    consumeMsgs chan "myQueueDE" Ack myCallbackDE
-    consumeMsgs chan "myQueueEN" Ack myCallbackEN
-
-
-    getLine -- wait for keypress
+    _ <- consumeMsgs chan "myQueueDE" Ack myCallbackDE
+    _ <- consumeMsgs chan "myQueueEN" Ack myCallbackEN
+    
+    
+    _ <- getLine -- wait for keypress
     closeConnection conn
     putStrLn "connection closed"
 
-
-
+    
+    
 
 myCallbackDE :: (Message,Envelope) -> IO ()
 myCallbackDE (msg, env) = do

--- a/examples/consumer/consumer.cabal
+++ b/examples/consumer/consumer.cabal
@@ -1,16 +1,6 @@
 Name:                consumer
-Version:             0.22.2
-Synopsis:            Client library for AMQP servers (currently only RabbitMQ)
-Description:         Client library for AMQP servers (currently only RabbitMQ)
-License:             BSD3
-Stability:           alpha
-License-file:        LICENSE
-Author:              Holger Reinhardt
-Category:            Network
-Maintainer:          Holger Reinhardt <hreinhardt@gmail.com>
+Version:             1
 Build-Type:          Simple
-Homepage:            https://github.com/hreinhardt/amqp
-bug-reports:         https://github.com/hreinhardt/amqp/issues
 Cabal-Version:       >=1.10
 
 
@@ -25,9 +15,3 @@ Executable amqp-example-consumer
                     , stm >= 2.4.0
                     , time
                     , containers >= 0.2
-
-
-
-source-repository head
-  type:     git
-  location: https://github.com/hreinhardt/amqp

--- a/examples/consumer/consumer.cabal
+++ b/examples/consumer/consumer.cabal
@@ -1,0 +1,33 @@
+Name:                consumer
+Version:             0.22.2
+Synopsis:            Client library for AMQP servers (currently only RabbitMQ)
+Description:         Client library for AMQP servers (currently only RabbitMQ)
+License:             BSD3
+Stability:           alpha
+License-file:        LICENSE
+Author:              Holger Reinhardt
+Category:            Network
+Maintainer:          Holger Reinhardt <hreinhardt@gmail.com>
+Build-Type:          Simple
+Homepage:            https://github.com/hreinhardt/amqp
+bug-reports:         https://github.com/hreinhardt/amqp/issues
+Cabal-Version:       >=1.10
+
+
+Executable amqp-example-consumer
+  default-language:   Haskell2010
+  Hs-Source-Dirs:     .
+  Main-is:            ExampleConsumer.hs
+  GHC-Options:        -Wall
+  Build-Depends:      base >= 4 && < 5
+                    , amqp >= 0.22.1
+                    , bytestring>=0.9
+                    , stm >= 2.4.0
+                    , time
+                    , containers >= 0.2
+
+
+
+source-repository head
+  type:     git
+  location: https://github.com/hreinhardt/amqp

--- a/examples/producer/ExampleProducer.hs
+++ b/examples/producer/ExampleProducer.hs
@@ -1,30 +1,31 @@
-{-# OPTIONS -XOverloadedStrings #-}
-module ExampleProducer where
+{-# LANGUAGE OverloadedStrings #-}
+module Main where
 
 import Network.AMQP
 
 import qualified Data.ByteString.Lazy.Char8 as BL
 
 
+main :: IO ()
 main = do
     conn <- openConnection "127.0.0.1" "/" "guest" "guest"
     chan <- openChannel conn
 
     
     --declare queues, exchanges and bindings
-    declareQueue chan newQueue {queueName = "myQueueDE"}
-    declareQueue chan newQueue {queueName = "myQueueEN"}
+    _ <- declareQueue chan newQueue {queueName = "myQueueDE"}
+    _ <- declareQueue chan newQueue {queueName = "myQueueEN"}
     
     declareExchange chan newExchange {exchangeName = "topicExchg", exchangeType = "topic"}
     bindQueue chan "myQueueDE" "topicExchg" "de.*"
     bindQueue chan "myQueueEN" "topicExchg" "en.*"
     
     --publish messages
-    publishMsg chan "topicExchg" "de.hello" 
+    _ <- publishMsg chan "topicExchg" "de.hello"
         (newMsg {msgBody = (BL.pack "hallo welt"), 
                  msgDeliveryMode = Just NonPersistent}
                 )
-    publishMsg chan "topicExchg" "en.hello" 
+    _ <- publishMsg chan "topicExchg" "en.hello"
         (newMsg {msgBody = (BL.pack "hello world"), 
                  msgDeliveryMode = Just NonPersistent}
                 )

--- a/examples/producer/producer.cabal
+++ b/examples/producer/producer.cabal
@@ -1,16 +1,6 @@
 Name:                producer
-Version:             0.22.2
-Synopsis:            Client library for AMQP servers (currently only RabbitMQ)
-Description:         Client library for AMQP servers (currently only RabbitMQ)
-License:             BSD3
-Stability:           alpha
-License-file:        LICENSE
-Author:              Holger Reinhardt
-Category:            Network
-Maintainer:          Holger Reinhardt <hreinhardt@gmail.com>
+Version:             1
 Build-Type:          Simple
-Homepage:            https://github.com/hreinhardt/amqp
-bug-reports:         https://github.com/hreinhardt/amqp/issues
 Cabal-Version:       >=1.10
 
 
@@ -25,10 +15,3 @@ Executable amqp-example-producer
                     , stm >= 2.4.0
                     , time
                     , containers >= 0.2
-
-
-
-source-repository head
-  type:     git
-  location: https://github.com/hreinhardt/amqp
-

--- a/examples/producer/producer.cabal
+++ b/examples/producer/producer.cabal
@@ -1,0 +1,34 @@
+Name:                producer
+Version:             0.22.2
+Synopsis:            Client library for AMQP servers (currently only RabbitMQ)
+Description:         Client library for AMQP servers (currently only RabbitMQ)
+License:             BSD3
+Stability:           alpha
+License-file:        LICENSE
+Author:              Holger Reinhardt
+Category:            Network
+Maintainer:          Holger Reinhardt <hreinhardt@gmail.com>
+Build-Type:          Simple
+Homepage:            https://github.com/hreinhardt/amqp
+bug-reports:         https://github.com/hreinhardt/amqp/issues
+Cabal-Version:       >=1.10
+
+
+Executable amqp-example-producer
+  default-language:   Haskell2010
+  Hs-Source-Dirs:     .
+  Main-is:            ExampleProducer.hs
+  GHC-Options:        -Wall
+  Build-Depends:      base >= 4 && < 5
+                    , amqp >= 0.22.1
+                    , bytestring>=0.9
+                    , stm >= 2.4.0
+                    , time
+                    , containers >= 0.2
+
+
+
+source-repository head
+  type:     git
+  location: https://github.com/hreinhardt/amqp
+

--- a/examples/tlsConsumer/ExampleTLSConsumer.hs
+++ b/examples/tlsConsumer/ExampleTLSConsumer.hs
@@ -1,36 +1,41 @@
-{-# OPTIONS -XOverloadedStrings #-}
-module ExampleConsumer where
+{-# LANGUAGE OverloadedStrings #-}
+module Main where
 
 import Network.AMQP
 
 import qualified Data.ByteString.Lazy.Char8 as BL
 
 
+main :: IO ()
 main = do
-    conn <- openConnection "127.0.0.1" "/" "guest" "guest"
+    let opts = defaultConnectionOpts {
+            coServers = [("127.0.0.1", 5671)]
+          , coTLSSettings = Just TLSTrusted
+          }
+    conn <- openConnection'' opts
     chan <- openChannel conn
 
-    
+
     --declare queues, exchanges and bindings
-    declareQueue chan newQueue {queueName = "myQueueDE"}
-    declareQueue chan newQueue {queueName = "myQueueEN"}
-    
+    _ <- declareQueue chan newQueue {queueName = "myQueueDE"}
+    _ <- declareQueue chan newQueue {queueName = "myQueueEN"}
+
     declareExchange chan newExchange {exchangeName = "topicExchg", exchangeType = "topic"}
     bindQueue chan "myQueueDE" "topicExchg" "de.*"
     bindQueue chan "myQueueEN" "topicExchg" "en.*"
-    
+
 
     --subscribe to the queues
-    consumeMsgs chan "myQueueDE" Ack myCallbackDE
-    consumeMsgs chan "myQueueEN" Ack myCallbackEN
-    
-    
-    getLine -- wait for keypress
+    _ <- consumeMsgs chan "myQueueDE" Ack myCallbackDE
+    _ <- consumeMsgs chan "myQueueEN" Ack myCallbackEN
+
+
+    _ <- getLine -- wait for keypress
     closeConnection conn
     putStrLn "connection closed"
 
-    
-    
+
+
 
 myCallbackDE :: (Message,Envelope) -> IO ()
 myCallbackDE (msg, env) = do

--- a/examples/tlsConsumer/tlsConsumer.cabal
+++ b/examples/tlsConsumer/tlsConsumer.cabal
@@ -1,16 +1,6 @@
 Name:                tlsConsumer
-Version:             0.22.2
-Synopsis:            Client library for AMQP servers (currently only RabbitMQ)
-Description:         Client library for AMQP servers (currently only RabbitMQ)
-License:             BSD3
-Stability:           alpha
-License-file:        LICENSE
-Author:              Holger Reinhardt
-Category:            Network
-Maintainer:          Holger Reinhardt <hreinhardt@gmail.com>
+Version:             1
 Build-Type:          Simple
-Homepage:            https://github.com/hreinhardt/amqp
-bug-reports:         https://github.com/hreinhardt/amqp/issues
 Cabal-Version:       >=1.10
 
 
@@ -25,9 +15,3 @@ Executable amqp-example-tls-consumer
                     , stm >= 2.4.0
                     , time
                     , containers >= 0.2
-
-
-source-repository head
-  type:     git
-  location: https://github.com/hreinhardt/amqp
-

--- a/examples/tlsConsumer/tlsConsumer.cabal
+++ b/examples/tlsConsumer/tlsConsumer.cabal
@@ -1,0 +1,33 @@
+Name:                tlsConsumer
+Version:             0.22.2
+Synopsis:            Client library for AMQP servers (currently only RabbitMQ)
+Description:         Client library for AMQP servers (currently only RabbitMQ)
+License:             BSD3
+Stability:           alpha
+License-file:        LICENSE
+Author:              Holger Reinhardt
+Category:            Network
+Maintainer:          Holger Reinhardt <hreinhardt@gmail.com>
+Build-Type:          Simple
+Homepage:            https://github.com/hreinhardt/amqp
+bug-reports:         https://github.com/hreinhardt/amqp/issues
+Cabal-Version:       >=1.10
+
+
+Executable amqp-example-tls-consumer
+  default-language:   Haskell2010
+  Hs-Source-Dirs:     .
+  Main-is:            ExampleTLSConsumer.hs
+  GHC-Options:        -Wall
+  Build-Depends:      base >= 4 && < 5
+                    , amqp >= 0.22.1
+                    , bytestring>=0.9
+                    , stm >= 2.4.0
+                    , time
+                    , containers >= 0.2
+
+
+source-repository head
+  type:     git
+  location: https://github.com/hreinhardt/amqp
+

--- a/examples/tlsProducer/ExampleTLSProducer.hs
+++ b/examples/tlsProducer/ExampleTLSProducer.hs
@@ -1,11 +1,12 @@
-{-# OPTIONS -XOverloadedStrings #-}
-module ExampleTLSProducer where
+{-# LANGUAGE OverloadedStrings #-}
+module Main where
 
 import Network.AMQP
 
 import qualified Data.ByteString.Lazy.Char8 as BL
 
 
+main :: IO ()
 main = do
     let opts = defaultConnectionOpts {
             coServers = [("127.0.0.1", 5671)]
@@ -16,19 +17,19 @@ main = do
 
 
     --declare queues, exchanges and bindings
-    declareQueue chan newQueue {queueName = "myQueueDE"}
-    declareQueue chan newQueue {queueName = "myQueueEN"}
+    _ <- declareQueue chan newQueue {queueName = "myQueueDE"}
+    _ <- declareQueue chan newQueue {queueName = "myQueueEN"}
 
     declareExchange chan newExchange {exchangeName = "topicExchg", exchangeType = "topic"}
     bindQueue chan "myQueueDE" "topicExchg" "de.*"
     bindQueue chan "myQueueEN" "topicExchg" "en.*"
 
     --publish messages
-    publishMsg chan "topicExchg" "de.hello"
+    _ <- publishMsg chan "topicExchg" "de.hello"
         (newMsg {msgBody = (BL.pack "hallo welt"),
                  msgDeliveryMode = Just NonPersistent}
                 )
-    publishMsg chan "topicExchg" "en.hello"
+    _ <- publishMsg chan "topicExchg" "en.hello"
         (newMsg {msgBody = (BL.pack "hello world"),
                  msgDeliveryMode = Just NonPersistent}
                 )

--- a/examples/tlsProducer/tlsProducer.cabal
+++ b/examples/tlsProducer/tlsProducer.cabal
@@ -1,0 +1,34 @@
+Name:                tlsProducer
+Version:             0.22.2
+Synopsis:            Client library for AMQP servers (currently only RabbitMQ)
+Description:         Client library for AMQP servers (currently only RabbitMQ)
+License:             BSD3
+Stability:           alpha
+License-file:        LICENSE
+Author:              Holger Reinhardt
+Category:            Network
+Maintainer:          Holger Reinhardt <hreinhardt@gmail.com>
+Build-Type:          Simple
+Homepage:            https://github.com/hreinhardt/amqp
+bug-reports:         https://github.com/hreinhardt/amqp/issues
+Cabal-Version:       >=1.10
+
+
+Executable amqp-example-tls-producer
+  default-language:   Haskell2010
+  Hs-Source-Dirs:     .
+  Main-is:            ExampleTLSProducer.hs
+  GHC-Options:        -Wall
+  Build-Depends:      base >= 4 && < 5
+                    , amqp >= 0.22.1
+                    , bytestring>=0.9
+                    , stm >= 2.4.0
+                    , time
+                    , containers >= 0.2
+
+
+
+source-repository head
+  type:     git
+  location: https://github.com/hreinhardt/amqp
+

--- a/examples/tlsProducer/tlsProducer.cabal
+++ b/examples/tlsProducer/tlsProducer.cabal
@@ -1,16 +1,6 @@
 Name:                tlsProducer
-Version:             0.22.2
-Synopsis:            Client library for AMQP servers (currently only RabbitMQ)
-Description:         Client library for AMQP servers (currently only RabbitMQ)
-License:             BSD3
-Stability:           alpha
-License-file:        LICENSE
-Author:              Holger Reinhardt
-Category:            Network
-Maintainer:          Holger Reinhardt <hreinhardt@gmail.com>
+Version:             1
 Build-Type:          Simple
-Homepage:            https://github.com/hreinhardt/amqp
-bug-reports:         https://github.com/hreinhardt/amqp/issues
 Cabal-Version:       >=1.10
 
 
@@ -25,10 +15,3 @@ Executable amqp-example-tls-producer
                     , stm >= 2.4.0
                     , time
                     , containers >= 0.2
-
-
-
-source-repository head
-  type:     git
-  location: https://github.com/hreinhardt/amqp
-


### PR DESCRIPTION
As proposed in https://github.com/hreinhardt/amqp/issues/105

I've added a new example in examples/connectionManagement that should demonstrate a way to handle connection and channel errors.

I've done the following to make this work. If any of this is a problem I'm happy to discuss options :)

- Added this new example and the existing examples as executables in the cabal project.
I think this was necessary because this new example needs a couple of additional imports (e.g. safe-exceptions) and making sure it builds seems like a good idea for anyone wanting to use it.
_Perhaps you would want a cabal flag so these are only build when the user actually wants them? I think you'd need to require a later version of cabal for this to work. I'm happy to add that this this PR if you want that._

   - The existing examples were moved into their own directories in `examples/` to make this work
   - I fixed a few simple hlint warnings that adding the examples revealed.

- Added a Makefile. Mostly so that there is an easy way to build all the examples `make build-examples`

- I've added comments to the new example, hopefully they explain the idea well.

Let me know what you think

Andre